### PR TITLE
Capacidad de aula

### DIFF
--- a/src/components/common/EventTabs.tsx
+++ b/src/components/common/EventTabs.tsx
@@ -144,10 +144,11 @@ export default function EventTabs({ events }: { events: IEvent[] }) {
                             wordBreak: 'break-word',
                             whiteSpace: 'normal'
                           }}
-                        >
+                        >/{' '}
                           {schedule.classroom?.name} / Piso{' '}
                           {schedule.classroom?.floor} /{' '}
-                          {schedule.classroom?.building.name}
+                          {schedule.classroom?.building.name} /{' '}
+                          Capacidad: {schedule.classroom?.capacity}
                         </Typography>
                         <MapSelector
                           building={schedule.classroom?.building.name}

--- a/src/components/common/InfoModal.tsx
+++ b/src/components/common/InfoModal.tsx
@@ -15,6 +15,7 @@ type InfoModalProps = {
   handleClose: () => void // Función para cerrar el Modal
   title: string
   subtitle?: string
+  capacity?: string
   type: 'course' | 'event' | 'schedule'
 }
 
@@ -23,9 +24,9 @@ export default function InfoModal({
   open,
   handleClose,
   title,
-  subtitle
+  subtitle,
+  capacity
 }: InfoModalProps) {
-
   return (
     <Modal
       open={open}
@@ -63,15 +64,36 @@ export default function InfoModal({
               backgroundColor: 'background.paper'
             }}
           >
-            <Typography
-              sx={{ display: 'flex', flexDirection: 'column' }}
-              id="modal-modal-title"
-              variant="h6"
-              component="h2"
-            >
-              <span>{title}</span>
-              <span>{subtitle}</span>
-            </Typography>
+            <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+              <Box sx={{ display: 'flex', flexDirection: 'column', gap: 0.5 }}>
+                <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                  <Typography variant="h6" component="h2" fontWeight="bold">
+                    {title}
+                  </Typography>
+                  {capacity && (
+                    <Box
+                      sx={{
+                        px: 1,
+                        py: 0.25,
+                        borderRadius: '999px',
+                        backgroundColor: 'action.hover',
+                        display: 'inline-flex',
+                        alignItems: 'center'
+                      }}
+                    >
+                      <Typography variant="caption" color="text.secondary">
+                        Capacidad: {capacity} personas
+                      </Typography>
+                    </Box>
+                  )}
+                </Box>
+                {subtitle && (
+                  <Typography variant="subtitle1" color="text.secondary">
+                    {subtitle}
+                  </Typography>
+                )}
+              </Box>
+            </Box>
             <IconButton
               aria-label="Cerrar Ventana"
               onClick={handleClose}

--- a/src/components/pages/map/Map.tsx
+++ b/src/components/pages/map/Map.tsx
@@ -36,6 +36,8 @@ import { eventService } from '@/data/services/EventService'
 // Contexts
 import { useNotification } from '@/context/NotificationContext'
 import { useLoader } from '@/context/LoaderContext'
+import { IClassroom } from '@/data/domain/Classroom'
+import { classroomService } from '@/data/services/ClassroomService'
 
 export default function Map() {
   const { control } = useForm({
@@ -53,6 +55,7 @@ export default function Map() {
 
   // Estado del modal
   const [classRoomId, setClassRoomId] = useState<null | string>(null)
+  const [classroom, setClassroom] = useState<IClassroom | null>(null)
   const [date, setDate] = useState<Date | null>(null)
   const [open, setOpen] = useState(false)
   const [pickerOpen, setPickerOpen] = useState(false)
@@ -94,12 +97,34 @@ export default function Map() {
     }
   }
 
+  const fetchClassroom = async (classRoomId: string) => {
+    try {
+      setLoader(true)
+      const classroomResponse = await classroomService.getById(classRoomId)
+      setLoader(false)
+      setClassroom(classroomResponse.data)
+    } catch (error) {
+      setLoader(false)
+      setOpen(false)
+      console.error('Error fetching classroom:', error)
+      setNotificationState({
+        title: 'Error al obtener aula',
+        type: 'error',
+        description: 'Ocurrió un error al cargar los datos del aula',
+        action: () => {}
+      })
+    }
+  }
+
   // Manejo del modal
   const handleOpen = async (newClassRoomId: string) => {
     const today = new Date()
     setDate(today)
     setClassRoomId(newClassRoomId)
-    await fetchEvents(newClassRoomId, today)
+    await Promise.all([
+      fetchClassroom(newClassRoomId),
+      fetchEvents(newClassRoomId, today)
+    ])
     setOpen(true)
   }
 
@@ -203,6 +228,7 @@ export default function Map() {
           handleClose={handleClose}
           title={classRoomId}
           subtitle={currentBuilding?.text}
+          capacity={classroom?.capacity?.toString()}
           type="schedule"
         >
           <DatePicker

--- a/src/data/services/ClassroomService.ts
+++ b/src/data/services/ClassroomService.ts
@@ -1,0 +1,19 @@
+import axios from 'axios'
+import { ServiceInterface } from './ServiceInterface'
+import { Response } from '../domain/Response'
+import { API_URL } from '@/config'
+import { IClassroom } from '../domain/Classroom'
+
+export class ClassroomService implements ServiceInterface {
+  baseUrl: string = `${API_URL}/classroom`
+
+  async getById(id: string): Promise<Response<IClassroom>> {
+    const classroomDto = await axios.get<Response<IClassroom>>(
+      `${this.baseUrl}/${id}`
+    )
+    const classroom = classroomDto.data
+    return classroom
+  }
+}
+
+export const classroomService = new ClassroomService()


### PR DESCRIPTION
Rastree donde se ve la informacion del aula son dos casos: cuando se clickea sobre un aula en el mapa y cuando se hace una busqueda y se clcikea sobre una materia. En ambos casos agregue la información de la capacidad del aula asignada.

Para el caso del click sobre el mapa hago una llamada al service pasandole el code del classroom y me traigo toda la info del aula (si bien solo necesito la capacidad, pensando en escalabilidad, si luego necesitamos mas data del aula este endpoint puede ser util):

<img width="1206" height="561" alt="image" src="https://github.com/user-attachments/assets/43ebbc86-b7f3-443e-9ccc-64c88a9cb6ea" />

Para el caso del click sobre la materia, ya el endpoint me traia la informacion del aula asi que simplemente agregue el dato de la misma:

<img width="1206" height="561" alt="image" src="https://github.com/user-attachments/assets/e17b28b0-1381-4537-9abc-7e7839c1ca53" />

Probar con la rama del back feat/limite-aulas

Closes #3 