### PR TITLE
Búsqueda con tags acumulables

### DIFF
--- a/src/components/common/SearchTagsInput.tsx
+++ b/src/components/common/SearchTagsInput.tsx
@@ -1,0 +1,140 @@
+import {
+  Autocomplete,
+  Box,
+  Chip,
+  Divider,
+  IconButton,
+  InputAdornment,
+  TextField
+} from '@mui/material'
+import { MagnifyingGlass, X } from '@phosphor-icons/react'
+import { useMemo, useState } from 'react'
+
+interface SearchTagsInputProps {
+  onSearch: (tags: string[]) => void
+  options: string[]
+  value: string[]
+}
+
+const normalizeTags = (tags: string[]) => {
+  const seen = new Set<string>()
+  const result: string[] = []
+
+  tags.forEach((tag) => {
+    const trimmed = tag.trim()
+    const key = trimmed.toLocaleLowerCase()
+    if (!trimmed || seen.has(key)) return
+    seen.add(key)
+    result.push(trimmed)
+  })
+
+  return result
+}
+
+export default function SearchTagsInput({
+  onSearch,
+  options,
+  value
+}: SearchTagsInputProps) {
+  const [inputValue, setInputValue] = useState('')
+
+  const hasQuery = useMemo(
+    () => value.length > 0 || inputValue.trim().length > 0,
+    [inputValue, value.length]
+  )
+
+  const emitTags = (nextTags: string[]) => {
+    onSearch(normalizeTags(nextTags))
+  }
+
+  const handleAddInputAsTag = () => {
+    const next = inputValue.trim()
+    if (!next) return
+    emitTags([...value, next])
+    setInputValue('')
+  }
+
+  const clearAll = () => {
+    if (value.length === 0 && inputValue.trim().length === 0) return
+    setInputValue('')
+    emitTags([])
+  }
+
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', bg: 'white' }}>
+      <Autocomplete
+        multiple
+        freeSolo
+        fullWidth
+        options={options}
+        value={value}
+        inputValue={inputValue}
+        filterSelectedOptions
+        forcePopupIcon={false}
+        onInputChange={(_, newInputValue) => setInputValue(newInputValue)}
+        onChange={(_, newValue) => {
+          emitTags(newValue)
+        }}
+        renderTags={(tagValue, getTagProps) =>
+          tagValue.map((option, index) => (
+            <Chip
+              variant="outlined"
+              label={option}
+              {...getTagProps({ index })}
+              key={`${option}-${index}`}
+              size="small"
+            />
+          ))
+        }
+        renderInput={(params) => (
+          <TextField
+            {...params}
+            label="Clase / Comisión / Profesor / Carrera"
+            onKeyDown={(event) => {
+              if (event.key !== 'Enter' && event.key !== ',') return
+              event.preventDefault()
+              handleAddInputAsTag()
+            }}
+            slotProps={{
+              input: {
+                ...params.InputProps,
+                type: 'search',
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <Divider sx={{ height: 28, m: 0.5 }} orientation="vertical" />
+                    <IconButton
+                      disableRipple
+                      sx={{
+                        padding: 1,
+                        fontSize: 32,
+                        height: '56px',
+                        display: 'flex',
+                        justifyContent: 'center',
+                        alignItems: 'center'
+                      }}
+                      aria-label={
+                        hasQuery && inputValue.trim().length === 0
+                          ? 'Limpiar búsqueda'
+                          : 'Agregar filtro de búsqueda'
+                      }
+                      onClick={() =>
+                        inputValue.trim().length > 0 ? handleAddInputAsTag() : clearAll()
+                      }
+                    >
+                      {hasQuery && inputValue.trim().length === 0 ? (
+                        <X size={32} alt="Limpiar búsqueda" color="#5f83b1" />
+                      ) : (
+                        <MagnifyingGlass size={32} alt="Agregar búsqueda" color="#5f83b1" />
+                      )}
+                    </IconButton>
+                  </InputAdornment>
+                )
+              }
+            }}
+            aria-label="Ingresar búsqueda"
+          />
+        )}
+      />
+    </Box>
+  )
+}

--- a/src/components/pages/search/Search.tsx
+++ b/src/components/pages/search/Search.tsx
@@ -13,7 +13,7 @@ import { ICourse, ICourseList } from '@/data/domain/Course'
 
 import { WarningCircle, Plus } from '@phosphor-icons/react'
 import { Box, Divider, Grid2, Tooltip, Typography } from '@mui/material'
-import SearchBar from '@/components/common/SearchBar'
+import SearchTagsInput from '@/components/common/SearchTagsInput'
 import ClassRoomCard from '@/components/common/ClassRoomCard/ClassRoomCard'
 import InfoModal from '@/components/common/InfoModal'
 import EventTabs from '@/components/common/EventTabs'
@@ -22,12 +22,13 @@ export default function Search() {
   const [selectedCourse, setSelectedCourse] = useState<ICourse | null>(null)
   const [open, setOpen] = useState(false)
   const [courses, setCourses] = useState<ICourseList[]>([])
+  const [searchTags, setSearchTags] = useState<string[]>([])
 
   const { setNotificationState } = useNotification()
   const { setLoader } = useLoader()
   const navigate = useNavigate()
   const { isAuthenticated } = useAuth()
-  const fetchCourses = async (query?: string) => {
+  const fetchCourses = async (query: string[] = []) => {
     setLoader(true)
     try {
       const courses = await courseService.getAll(query)
@@ -89,12 +90,13 @@ export default function Search() {
     setOpen(false)
   }
 
-  const search = (query: string) => {
-    fetchCourses(query)
+  const search = (tags: string[]) => {
+    setSearchTags(tags)
+    fetchCourses(tags)
   }
 
   useEffect(() => {
-    fetchCourses()
+    fetchCourses([])
   }, [])
 
   return (
@@ -102,8 +104,9 @@ export default function Search() {
     <Box className="interactive-page">
       {/* Barra de búsqueda fija */}
       <Box position="sticky" top="0" zIndex="10">
-        <SearchBar
+        <SearchTagsInput
           onSearch={search}
+          value={searchTags}
           options={courses.map((course) => course.name)}
         />
         <Divider variant="middle" flexItem />

--- a/src/data/services/CourseService.ts
+++ b/src/data/services/CourseService.ts
@@ -12,8 +12,20 @@ import { API_URL } from '@/config'
 export class CourseService implements ServiceInterface {
   baseUrl: string = `${API_URL}/courses`
 
-  async getAll(query?: string): Promise<Response<ICourseList[]>> {
-    const url = query ? `${this.baseUrl}?query=${query}` : this.baseUrl
+  async getAll(query?: string | string[]): Promise<Response<ICourseList[]>> {
+    const normalizedQuery =
+      typeof query === 'string'
+        ? query
+          ? [query]
+          : []
+        : (query ?? []).filter((q) => q.trim().length > 0)
+
+    const url = normalizedQuery.length
+      ? `${this.baseUrl}?${new URLSearchParams(
+          normalizedQuery.map((q) => ['query', q])
+        ).toString()}`
+      : this.baseUrl
+
     const courseDTOs = await axios.get<Response<ICourseList[]>>(url)
     const courses = courseDTOs.data
     return courses


### PR DESCRIPTION
Se creó un componente aparte `SearchTagsInput` que se usa solamente en la ruta para buscar materia para no afectar el comportamiento del `SearchBar`.

El componente permite ir agregando tags al buscar materias y eliminarlos individualmente, cada ves que se agrega/elimina uno dispara la búsqueda de nuevo.

<img width="1843" height="607" alt="busqueda" src="https://github.com/user-attachments/assets/3f448b9e-fa35-41bb-81be-39970e1ae1d6" />
