### PR TITLE
Tuneo pagina de registro

### DIFF
--- a/src/components/pages/login/Login.tsx
+++ b/src/components/pages/login/Login.tsx
@@ -1,6 +1,6 @@
 import { MouseEvent } from 'react'
 import { useForm, Controller, SubmitHandler } from 'react-hook-form'
-import {TextField, Button, Box, FormControl, IconButton, InputAdornment, InputLabel, OutlinedInput, FormHelperText, Tooltip} from '@mui/material'
+import { TextField, Button, Box, FormControl, IconButton, InputAdornment, InputLabel, OutlinedInput, FormHelperText, Tooltip } from '@mui/material'
 import { useNavigate } from 'react-router-dom'
 import { useAuth } from '../../../context/AuthContext.tsx'
 import { LoginRequest } from '../../../data/domain/User.ts'
@@ -75,11 +75,11 @@ export default function Login() {
         component="form"
         onSubmit={handleSubmit(onSubmit)}
         className="form"
-        // sx={{
-        //     maxWidth: 400,
-        //     margin: '0 auto',
-        //     border: '1px solid #ccc',
-        // }}
+      // sx={{
+      //     maxWidth: 400,
+      //     margin: '0 auto',
+      //     border: '1px solid #ccc',
+      // }}
       >
         <img
           src={logoUnsam}
@@ -138,7 +138,7 @@ export default function Login() {
                 data-testid="password-input"
                 endAdornment={
                   <InputAdornment position="end">
-                    <Tooltip title={showPassword? 'Ocultar':'Mostrar'} arrow>
+                    <Tooltip title={showPassword ? 'Ocultar' : 'Mostrar'} arrow>
                       <IconButton
                         aria-label={
                           showPassword
@@ -171,16 +171,14 @@ export default function Login() {
         </Button>
 
         {/* Register Button */}
-        <span style={{ cursor: 'not-allowed' }}>
-          <Button
-            disabled
-            variant="outlined"
-            color="primary"
-            fullWidth
-            onClick={() => navigate('/registrar')}>
-            <FingerprintSimple size={32} alt="Registrarse" /> Registrarse
-          </Button>
-        </span>
+        <Button
+          variant="outlined"
+          color="primary"
+          fullWidth
+          onClick={() => navigate('/registrar')}>
+          <FingerprintSimple size={32} alt="Registrarse" /> Registrarse
+        </Button>
+
       </Box>
     </main>
   )

--- a/src/components/pages/register/Register.tsx
+++ b/src/components/pages/register/Register.tsx
@@ -77,7 +77,7 @@ export default function Register() {
   }
 
   return (
-    <main className="register-page" style={{ overflowY: 'auto', minHeight: '100%', display: 'flex', justifyContent: 'center', alignItems: 'flex-start'}}>
+    <main className="register-page" style={{ height: '100%', overflowY: 'auto' }}>
       {/*Contenedor general de la vista */}
       <Box
         sx={{
@@ -86,7 +86,7 @@ export default function Register() {
           padding: '2rem',
           backgroundColor: 'white',
           borderRadius: { xs: 0, sm: 2 },
-          mt: { xs: '8rem', sm: '20rem', md:'5rem'},
+          mt: { xs: '8rem', sm: '20rem', md:'9rem'},
           mb: { xs: 0, sm: '2rem' },
           maxWidth: { sm: 500, md: 700 },
           width: { xs: '100%', sm: '90%' },

--- a/src/components/pages/register/Register.tsx
+++ b/src/components/pages/register/Register.tsx
@@ -4,7 +4,6 @@ import {
   TextField,
   Button,
   Typography,
-  Container,
   Link
 } from '@mui/material'
 import { useNavigate } from 'react-router-dom'
@@ -78,17 +77,24 @@ export default function Register() {
   }
 
   return (
-    <main className="register-page">
-      <Container
+    <main className="register-page" style={{ overflowY: 'auto', minHeight: '100%', display: 'flex', justifyContent: 'center', alignItems: 'flex-start'}}>
+      {/*Contenedor general de la vista */}
+      <Box
         sx={{
           display: 'flex',
           flexDirection: 'column',
-          justifyContent: 'center',
           padding: '2rem',
           backgroundColor: 'white',
-          borderRadius: 2
+          borderRadius: { xs: 0, sm: 2 },
+          mt: { xs: '8rem', sm: '20rem', md:'5rem'},
+          mb: { xs: 0, sm: '2rem' },
+          maxWidth: { sm: 500, md: 700 },
+          width: { xs: '100%', sm: '90%' },
+          mx: 'auto',
         }}
+        aria-label="Formulario de registro"
       >
+        {/*Contenedor de la imagen*/}
         <Box
           component="img"
           sx={{
@@ -101,6 +107,8 @@ export default function Register() {
           alt="Logo de la universidad."
           src="/logo-unsam-largo.png"
         />
+
+        {/*Contenedor del titulo e inputs*/}
         <Box
           sx={{
             display: 'flex',
@@ -289,7 +297,7 @@ export default function Register() {
             </Typography>
           </Box>
         </Box>
-      </Container>
+      </Box>
     </main>
   )
 }

--- a/src/components/pages/register/register.css
+++ b/src/components/pages/register/register.css
@@ -1,3 +1,0 @@
-.register-page {
-  padding: 2rem;
-}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,70 +2,8 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from '@/App.tsx'
-import { createTheme, responsiveFontSizes, ThemeProvider } from '@mui/material'
-import { esES } from '@mui/x-date-pickers/locales'
-
-let unsamTheme = createTheme(
-  {
-    typography: {
-      fontFamily: ['Saira' /*Fuente que usa la UNSAM*/, 'sans-serif'].join(',')
-    },
-    colorSchemes: {
-      light: {
-        palette: {
-          primary: {
-            main: '#7DA1C4' /*Pantone 645 como indica la UNSAM, si cambia es por #00DC8C (color de ECyT).*/,
-            contrastText:
-              '#0F0F0F' /* Azul oscuro/casi negro para el texto en el color principal*/
-          },
-          secondary: {
-            main: '#0F0F0F'
-          },
-          error: {
-            main: '#ef9a9a'
-          },
-          warning: {
-            main: '#ff9800'
-          },
-          tonalOffset: 0.1
-        }
-      }
-      /* dark: {
-      palette: {
-        primary: {
-          main:'#7DA1C4',
-          contrastText: '#FFFFFF'
-        },
-        secondary:{
-          main:'#FFFFFF'
-        }
-      }
-    } */
-    },
-    components: {
-      MuiIconButton: {
-        defaultProps: {
-          color: 'secondary',
-          disableRipple: true,
-          disableFocusRipple: true
-        }
-      },
-      MuiOutlinedInput: {
-        styleOverrides: {
-          input: {
-            '&:-webkit-autofill': {
-              boxShadow: '0 0 0 1000px white inset',
-              WebkitTextFillColor: '#000',
-              transition: 'background-color 5000s ease-in-out 0s',
-            }
-          }
-        }
-      }
-    }
-  },
-  esES
-)
-unsamTheme = responsiveFontSizes(unsamTheme)
+import unsamTheme from '@/styles/theme.ts'
+import { ThemeProvider} from '@mui/material'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -4,6 +4,7 @@ import { RouteObject } from 'react-router-dom'
 
 import { ProtectedRoute } from './components/common/ProtectedRoute'
 import EventForm from './components/pages/form/components/EventForm'
+import Register from './components/pages/register/Register'
 
 // Lazy Components
 // const Register = lazy(() => import('@/components/pages/register/Register'))
@@ -22,7 +23,7 @@ const Periods = lazy(() => import('@/components/pages/main/periods/ListPeriod'))
 export const routes: RouteObject[] = [
   { path: '/', element: <Welcome /> },
   { path: '/ingresar', element: <Login /> },
-  /* { path: '/registrar', element: <Register /> }, */
+  { path: '/registrar', element: <Register /> },
   { path: '/buscar', element: <Search /> },
   {
     path: '/mapa/:building/:level',

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -1,0 +1,80 @@
+import { createTheme, responsiveFontSizes } from '@mui/material'
+import { esES } from '@mui/x-date-pickers/locales'
+
+let unsamTheme = createTheme(
+  {
+    typography: {
+      fontFamily: ['Saira' /*Fuente que usa la UNSAM*/, 'sans-serif'].join(',')
+    },
+    colorSchemes: {
+      light: {
+        palette: {
+          primary: {
+            main: '#7DA1C4' /*Pantone 645 como indica la UNSAM, si cambia es por #00DC8C (color de ECyT).*/,
+            contrastText:
+              '#0F0F0F' /* Azul oscuro/casi negro para el texto en el color principal*/
+          },
+          secondary: {
+            main: '#0F0F0F'
+          },
+          error: {
+            main: '#ef9a9a'
+          },
+          warning: {
+            main: '#ff9800'
+          },
+          tonalOffset: 0.1
+        }
+      }
+      /* dark: {
+      palette: {
+        primary: {
+          main:'#7DA1C4',
+          contrastText: '#FFFFFF'
+        },
+        secondary:{
+          main:'#FFFFFF'
+        }
+      }
+    } */
+    },
+    components: {
+      MuiIconButton: {
+        defaultProps: {
+          color: 'secondary',
+          disableRipple: true,
+          disableFocusRipple: true
+        }
+      },
+      MuiOutlinedInput: {
+        styleOverrides: {
+          input: {
+            '&:-webkit-autofill': {
+              boxShadow: '0 0 0 1000px white inset',
+              WebkitTextFillColor: '#000',
+              transition: 'background-color 5000s ease-in-out 0s',
+            }
+          }
+        }
+      }
+    }
+  },
+  esES
+)
+
+unsamTheme = createTheme(unsamTheme, {
+  components: {
+    MuiButton: {
+      styleOverrides: {
+        outlinedPrimary: {
+          '&:hover': {
+            backgroundColor: 'rgba(95, 94, 94, 0.06)',
+            borderColor: unsamTheme.palette.primary.main,
+          }
+        }
+      }
+    }
+  }
+})
+
+export default unsamTheme = responsiveFontSizes(unsamTheme)


### PR DESCRIPTION
## Theme.ts
- Saque toda la configuración del theme que estaba en `main.tsx` y la lleve a la carpeta `/styles/theme.ts` porque me parecia confuso que estuviera todo junto.
- En el `theme.ts` ahora hay una nueva config para los botones de `variant= outlined`: es un hover con colorcito y un border color usando el main de la paleta definida.

#### Antes se veia asi:
- Sin un relleno de color en el boton y un borde color **azul francia**
<img width="532" height="310" alt="image" src="https://github.com/user-attachments/assets/385f793c-edb9-4618-93b5-e13a2f011670" />

<br></br>

#### Ahora se ve asi: 
- Esto afecta a todos los botones de tipo outlined asi que el boton de `Registrarse` también se ve así
<img width="512" height="287" alt="image" src="https://github.com/user-attachments/assets/1f6d653b-b099-497b-849d-6be613033a20" />
<img width="599" height="141" alt="image" src="https://github.com/user-attachments/assets/6fe59190-af2e-4d22-9af9-392b018dc434" />

## Login
- Obvio que le saque el span y el disabled que tenia el boton de registrarse para que no esté bloqueada la navegación

## Register
- La pagina estaba hecha pero estaba rota en estilo, en especial en mobile.
- La intente arreglar pero honestamente es imposible laburar sin un Layout compartido, terminó siendo estilo con sx en el componente pero es una bolsa de gatos.
- Quedaria pendiente un refactor del estilo armando un layout para estandarizar el estilo de todas las paginas.
- El `.page-structure` de App.css rompe toda la vista y me obliga a dar mucho estilado que no deberia hacer falta

### Desktop
<img width="916" height="886" alt="image" src="https://github.com/user-attachments/assets/58583ce3-a499-4471-becc-4e8a14b59575" />

### Tablet
<img width="893" height="836" alt="image" src="https://github.com/user-attachments/assets/76593b10-0d8b-4135-96d4-c0ed6045ad48" />
<img width="830" height="495" alt="image" src="https://github.com/user-attachments/assets/56e71ab5-93fc-4cc9-8852-8ac547716a64" />

### Mobile
<img width="533" height="893" alt="image" src="https://github.com/user-attachments/assets/187747fd-cf59-4e2a-940b-89a1e27e4df7" />
<img width="487" height="539" alt="image" src="https://github.com/user-attachments/assets/7dd96ae7-b43a-4da8-bbf5-f9cc2b7cf454" />

