### PR TITLE
Fix - Agregar evento VIRTUAL 

### DIFF
--- a/src/components/pages/form/components/EventForm.tsx
+++ b/src/components/pages/form/components/EventForm.tsx
@@ -334,7 +334,12 @@ export default function EventForm() {
         courseID: needsCourse(data.type) ? data.courseID : '',
         customPeriodStart: sendCustomPeriod ? data.customPeriodStart : null,
         customPeriodEnd: sendCustomPeriod ? data.customPeriodEnd : null,
-        schedules: data.schedules.map(mapScheduleToBackend)
+        schedules: data.schedules.map((sch) => {
+          const cleaned = sch.isVirtual
+            ? { ...sch, buildingId: '', classroomId: '' }
+            : sch
+          return mapScheduleToBackend(cleaned)
+        })
       }
 
       if (id) await eventService.update(payload)
@@ -840,28 +845,28 @@ export default function EventForm() {
                   alignItems="center"
                 >
                   <Controller
-  name={`schedules.${idx}.isVirtual`}
-  control={control}
-  render={({ field }) => (
-    <FormControlLabel
-      sx={{ alignSelf: 'start' }}
-      control={
-        <Switch
-          {...field}
-          checked={field.value}
-          onChange={(e) => {
-            field.onChange(e.target.checked)
-            if (e.target.checked) {
-              setValue(buildField, '')
-              setValue(classField, '')
-            }
-          }}
-        />
-      }
-      label="Virtual"
-    />
-  )}
-/>
+                    name={`schedules.${idx}.isVirtual`}
+                    control={control}
+                    render={({ field }) => (
+                      <FormControlLabel
+                        sx={{ alignSelf: 'start' }}
+                        control={
+                          <Switch
+                            {...field}
+                            checked={field.value}
+                            onChange={(e) => {
+                              field.onChange(e.target.checked)
+                              if (e.target.checked) {
+                                setValue(buildField, '')
+                                setValue(classField, '')
+                              }
+                            }}
+                          />
+                        }
+                        label="Virtual"
+                      />
+                    )}
+                  />
 
                   <Controller
                     name={buildField}

--- a/src/components/pages/form/components/EventForm.tsx
+++ b/src/components/pages/form/components/EventForm.tsx
@@ -840,16 +840,28 @@ export default function EventForm() {
                   alignItems="center"
                 >
                   <Controller
-                    name={`schedules.${idx}.isVirtual`}
-                    control={control}
-                    render={({ field }) => (
-                      <FormControlLabel
-                        sx={{ alignSelf: 'start' }}
-                        control={<Switch {...field} checked={field.value} />}
-                        label="Virtual"
-                      />
-                    )}
-                  />
+  name={`schedules.${idx}.isVirtual`}
+  control={control}
+  render={({ field }) => (
+    <FormControlLabel
+      sx={{ alignSelf: 'start' }}
+      control={
+        <Switch
+          {...field}
+          checked={field.value}
+          onChange={(e) => {
+            field.onChange(e.target.checked)
+            if (e.target.checked) {
+              setValue(buildField, '')
+              setValue(classField, '')
+            }
+          }}
+        />
+      }
+      label="Virtual"
+    />
+  )}
+/>
 
                   <Controller
                     name={buildField}
@@ -860,6 +872,7 @@ export default function EventForm() {
                         sx={{ flex: 1, width: { xs: '100%' } }}
                         getOptionLabel={(b) => b.name}
                         isOptionEqualToValue={(o, v) => o.id === v.id}
+                        disabled={watch(`schedules.${idx}.isVirtual`)}
                         value={
                           buildings.find((b) => b.id === field.value) ?? null
                         }
@@ -889,6 +902,9 @@ export default function EventForm() {
                         options={classroomsFiltered}
                         getOptionLabel={(o) => o.label}
                         isOptionEqualToValue={(o, v) => o.id === v.id}
+                        disabled={
+                          watch(`schedules.${idx}.isVirtual`) || !buildingIdSel
+                        }
                         value={
                           classroomsFiltered.find(
                             (c) => c.id === field.value


### PR DESCRIPTION
Al marcar un horario como "Virtual", los campos de edificio y aula quedaban visualmente deshabilitados pero podían seleccionarse igualmente. 

Se realizaron cambios en eventForm.tsx para solucionar el problema. Al apretar virtual no permite seleccionar nada. Y además si habías seleccionado algo previamente y lo pones virtual, elimina los campos seleccionados. 

<img width="917" height="753" alt="image" src="https://github.com/user-attachments/assets/a5735f84-b6c9-4176-ae18-f788a881410a" />
