### PR TITLE
Refactor/room styles

### DIFF
--- a/src/components/common/map/MapStyle.tsx
+++ b/src/components/common/map/MapStyle.tsx
@@ -1,0 +1,29 @@
+export interface MapAreaStyle {
+  fill: string
+  stroke: string
+  strokeWidth: number
+}
+
+/**
+ * Aplica el estilo visual para elementos del mapa que no son seleccionables.
+ * Cuando existe una selección activa, el elemento se atenúa para destacar
+ * el aula o laboratorio seleccionado.
+ */
+export function getMapStyle(
+  baseStyle: MapAreaStyle,
+  hasSelection: boolean
+): MapAreaStyle {
+  if (hasSelection) {
+    return {
+      fill: 'white',
+      stroke: '#cccccc',
+      strokeWidth: 1,
+    }
+  }
+
+  return {
+    fill: baseStyle.fill,
+    stroke: baseStyle.stroke,
+    strokeWidth: baseStyle.strokeWidth,
+  }
+}

--- a/src/components/common/map/RoomStyle.tsx
+++ b/src/components/common/map/RoomStyle.tsx
@@ -1,0 +1,39 @@
+import { mapColors } from "@/components/pages/map/mapColors"
+
+
+type RoomType = 'classroom' | 'lab' 
+
+
+export function getRoomStyle(type: RoomType, isSelected: boolean, hasSelection: boolean) {
+  const baseStyles = {
+    classroom: mapColors.classrooms,
+    lab: mapColors.lab,
+  }
+
+  const base = baseStyles[type]
+
+  //resalta el aula/laboratorio seleccionado
+  if (isSelected) {
+    return {
+      fill: '#d32f2f',
+      stroke: '#b71c1c',
+      strokeWidth: base.strokeWidth,
+    }
+  }
+
+  //cuando hay una selección activa, atenúa el resto para destacar la seleccionada
+  if (hasSelection) {
+    return {
+      fill: 'white',
+      stroke: '#cccccc',
+      strokeWidth: 1,
+    }
+  }
+
+  //estado normal del mapa cuando no hay selección
+  return {
+    fill: base.fill,
+    stroke: base.stroke,
+    strokeWidth: base.strokeWidth,
+  }
+}

--- a/src/components/common/map/RoomStyle.tsx
+++ b/src/components/common/map/RoomStyle.tsx
@@ -1,14 +1,16 @@
 import { mapColors } from "@/components/pages/map/mapColors"
 
 
-type RoomType = 'classroom' | 'lab' | 'lab_h'
+type RoomType = 'classroom' | 'lab' | 'lab_h' | 'eCyT' | 'intsTrans'
 
 
 export function getRoomStyle(type: RoomType, isSelected: boolean, hasSelection: boolean) {
   const baseStyles = {
     classroom: mapColors.classrooms,
     lab: mapColors.lab,
-    lab_h: mapColors.humanidades
+    lab_h: mapColors.humanidades,
+    eCyT: mapColors.escuelaCyt,
+    intsTrans: mapColors.institutoTransporte
   }
 
   const base = baseStyles[type]

--- a/src/components/common/map/RoomStyle.tsx
+++ b/src/components/common/map/RoomStyle.tsx
@@ -1,13 +1,14 @@
 import { mapColors } from "@/components/pages/map/mapColors"
 
 
-type RoomType = 'classroom' | 'lab' 
+type RoomType = 'classroom' | 'lab' | 'lab_h'
 
 
 export function getRoomStyle(type: RoomType, isSelected: boolean, hasSelection: boolean) {
   const baseStyles = {
     classroom: mapColors.classrooms,
     lab: mapColors.lab,
+    lab_h: mapColors.humanidades
   }
 
   const base = baseStyles[type]

--- a/src/components/common/map/aulario/AularioNave3PlantaAlta.tsx
+++ b/src/components/common/map/aulario/AularioNave3PlantaAlta.tsx
@@ -1,5 +1,6 @@
 import { mapColors } from '../../../pages/map/mapColors'
 import { getRoomStyle } from '../RoomStyle'
+import RoomText from '../RoomText'
 
 interface AularioNave3PlantaAltaProps {
   selectedCode?: string // Cambiado de selectedClassRoomId
@@ -125,19 +126,7 @@ export default function AularioNave3PlantaAlta({ selectedCode, handleOpen }: Aul
           onClick={() => handleOpen?.('AN3-A20')}
           className={`classRoom ${isSelected('AN3-A20') ? 'selected' : ''}`}>
           <path d="M80.277596,39.238172h244.655514v189.225753h-244.655514Z" transform="translate(0 0.000001)" />
-          <text
-            dx="0"
-            dy="0"
-            fontFamily='"eBHsLTiXjpU1:::Roboto"'
-            fontSize="25"
-            fontWeight="400"
-            transform="translate(165 135)"
-            strokeWidth="0"
-          >
-            <tspan y="0" fontWeight="700" strokeWidth="0">
-              A20
-            </tspan>
-          </text>
+          <RoomText x={165} y={135} lineHeight={15} fontSize={25} lines={[ { text: 'A20' }, ]} />
         </g>
 
         {/* A19 */}
@@ -145,19 +134,7 @@ export default function AularioNave3PlantaAlta({ selectedCode, handleOpen }: Aul
           onClick={() => handleOpen?.('AN3-A19')}
           className={`classRoom ${isSelected('AN3-A19') ? 'selected' : ''}`} >
           <path d="M571.5,87.978136h166.289298v140.485784h-166.289298v-140.485784Z" transform="translate(0 0.000002)" />
-          <text
-            dx="0"
-            dy="0"
-            fontFamily='"eBHsLTiXjpU1:::Roboto"'
-            fontSize="25"
-            fontWeight="400"
-            transform="translate(635 165)"
-            strokeWidth="0"
-          >
-            <tspan y="0" fontWeight="700" strokeWidth="0">
-              A19
-            </tspan>
-          </text>
+          <RoomText x={635} y={165} lineHeight={15} fontSize={25} lines={[ { text: 'A19' }, ]} />
         </g>
         {/* A18 */}
         <g style={getRoomStyle('classroom', isSelected('AN3-A18'), hasSelection)}
@@ -167,19 +144,7 @@ export default function AularioNave3PlantaAlta({ selectedCode, handleOpen }: Aul
             d="M737.789297,39.238172h327.800168v189.225749l-327.800168-.428984v-188.796765Z"
             transform="translate(.000001 0.000001)"
           />
-          <text
-            dx="0"
-            dy="0"
-            fontFamily='"eBHsLTiXjpU1:::Roboto"'
-            fontSize="25"
-            fontWeight="400"
-            transform="translate(895 140)"
-            strokeWidth="0"
-          >
-            <tspan y="0" fontWeight="700" strokeWidth="0">
-              A18
-            </tspan>
-          </text>
+          <RoomText x={895} y={140} lineHeight={15} fontSize={25} lines={[ { text: 'A18' }, ]} />
         </g>
       </svg>
     </>

--- a/src/components/common/map/aulario/AularioNave3PlantaAlta.tsx
+++ b/src/components/common/map/aulario/AularioNave3PlantaAlta.tsx
@@ -1,4 +1,5 @@
 import { mapColors } from '../../../pages/map/mapColors'
+import { getRoomStyle } from '../RoomStyle'
 
 interface AularioNave3PlantaAltaProps {
   selectedCode?: string // Cambiado de selectedClassRoomId
@@ -6,11 +7,9 @@ interface AularioNave3PlantaAltaProps {
   handleOpen?: (classRoomId: string) => void
 }
 
-export default function AularioNave3PlantaAlta({
-  selectedCode,
-  handleOpen
-}: AularioNave3PlantaAltaProps) {
+export default function AularioNave3PlantaAlta({ selectedCode, handleOpen }: AularioNave3PlantaAltaProps) {
   const isSelected = (id: string) => id === selectedCode
+  const hasSelection = !!selectedCode //convierte selectedCode a boolean
 
   return (
     <>
@@ -122,19 +121,10 @@ export default function AularioNave3PlantaAlta({
         </g>
 
         {/* A20 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('AN3-A20'), hasSelection)}
           onClick={() => handleOpen?.('AN3-A20')}
-          className={`classRoom ${isSelected('AN3-A20') ? 'selected' : ''}`}
-        >
-          <path
-            d="M80.277596,39.238172h244.655514v189.225753h-244.655514Z"
-            transform="translate(0 0.000001)"
-          />
+          className={`classRoom ${isSelected('AN3-A20') ? 'selected' : ''}`}>
+          <path d="M80.277596,39.238172h244.655514v189.225753h-244.655514Z" transform="translate(0 0.000001)" />
           <text
             dx="0"
             dy="0"
@@ -151,19 +141,10 @@ export default function AularioNave3PlantaAlta({
         </g>
 
         {/* A19 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('AN3-A19'), hasSelection)}
           onClick={() => handleOpen?.('AN3-A19')}
-          className={`classRoom ${isSelected('AN3-A19') ? 'selected' : ''}`}
-        >
-          <path
-            d="M571.5,87.978136h166.289298v140.485784h-166.289298v-140.485784Z"
-            transform="translate(0 0.000002)"
-          />
+          className={`classRoom ${isSelected('AN3-A19') ? 'selected' : ''}`} >
+          <path d="M571.5,87.978136h166.289298v140.485784h-166.289298v-140.485784Z" transform="translate(0 0.000002)" />
           <text
             dx="0"
             dy="0"
@@ -179,15 +160,9 @@ export default function AularioNave3PlantaAlta({
           </text>
         </g>
         {/* A18 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('AN3-A18'), hasSelection)}
           onClick={() => handleOpen?.('AN3-A18')}
-          className={`classRoom ${isSelected('AN3-A18') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('AN3-A18') ? 'selected' : ''}`}>
           <path
             d="M737.789297,39.238172h327.800168v189.225749l-327.800168-.428984v-188.796765Z"
             transform="translate(.000001 0.000001)"

--- a/src/components/common/map/aulario/AularioNave3PlantaBaja.tsx
+++ b/src/components/common/map/aulario/AularioNave3PlantaBaja.tsx
@@ -1,5 +1,6 @@
 import { Toilet } from '@phosphor-icons/react'
 import { mapColors } from '../../../pages/map/mapColors'
+import { getRoomStyle } from '../RoomStyle'
 
 interface AularioNaveProps {
   selectedCode?: string // Cambiado de selectedClassRoomId
@@ -7,11 +8,9 @@ interface AularioNaveProps {
   handleOpen?: (classRoomId: string) => void
 }
 
-export default function AularioNave3PlantaBaja({
-  selectedCode,
-  handleOpen
-}: AularioNaveProps) {
+export default function AularioNave3PlantaBaja({ selectedCode, handleOpen }: AularioNaveProps) {
   const isSelected = (id: string) => id === selectedCode
+  const hasSelection = !!selectedCode
 
   return (
     <>
@@ -127,12 +126,7 @@ export default function AularioNave3PlantaBaja({
         </g>
 
         {/* A17 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('AN3-A17'), hasSelection)}
           onClick={() => handleOpen?.('AN3-A17')}
           transform="translate(.000001 0)"
           className={`classRoom ${isSelected('AN3-A17') ? 'selected' : ''}`}
@@ -156,16 +150,10 @@ export default function AularioNave3PlantaBaja({
           </text>
         </g>
         {/* A16 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('AN3-A16') , hasSelection)}
           onClick={() => handleOpen?.('AN3-A16')}
           transform="translate(.000001 0)"
-          className={`classRoom ${isSelected('AN3-A16') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('AN3-A16') ? 'selected' : ''}`}>
           <path
             d="M571.5,87.978136h166.289298v140.485784h-166.289298v-140.485784Z"
             transform="translate(0 0.000002)"
@@ -185,12 +173,7 @@ export default function AularioNave3PlantaBaja({
           </text>
         </g>
         {/* A15 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('AN3-A15'), hasSelection)}
           onClick={() => handleOpen?.('AN3-A15')}
           transform="translate(.000001 0)"
           className={`classRoom ${isSelected('AN3-A15') ? 'selected' : ''}`}

--- a/src/components/common/map/aulario/AularioNave3PlantaBaja.tsx
+++ b/src/components/common/map/aulario/AularioNave3PlantaBaja.tsx
@@ -1,6 +1,7 @@
 import { Toilet } from '@phosphor-icons/react'
 import { mapColors } from '../../../pages/map/mapColors'
 import { getRoomStyle } from '../RoomStyle'
+import RoomText from '../RoomText'
 
 interface AularioNaveProps {
   selectedCode?: string // Cambiado de selectedClassRoomId
@@ -135,19 +136,7 @@ export default function AularioNave3PlantaBaja({ selectedCode, handleOpen }: Aul
             d="M80.277596,39.238172h244.655514l.16554,42.911613h-28.836108v101.936404h28.670568v43.948748l-244.655514.428984v-189.225749Z"
             transform="translate(0 0.000001)"
           />
-          <text
-            dx="0"
-            dy="0"
-            fontFamily='"eBHsLTiXjpU1:::Roboto"'
-            fontSize="25"
-            fontWeight="400"
-            transform="translate(165 135)"
-            strokeWidth="0"
-          >
-            <tspan y="0" fontWeight="700" strokeWidth="0">
-              A17
-            </tspan>
-          </text>
+          <RoomText x={165} y={135} lineHeight={15} fontSize={25} lines={[ { text: 'A17' }, ]} />
         </g>
         {/* A16 */}
         <g style={getRoomStyle('classroom', isSelected('AN3-A16') , hasSelection)}
@@ -158,19 +147,7 @@ export default function AularioNave3PlantaBaja({ selectedCode, handleOpen }: Aul
             d="M571.5,87.978136h166.289298v140.485784h-166.289298v-140.485784Z"
             transform="translate(0 0.000002)"
           />
-          <text
-            dx="0"
-            dy="0"
-            fontFamily='"eBHsLTiXjpU1:::Roboto"'
-            fontSize="25"
-            fontWeight="400"
-            transform="translate(635 165)"
-            strokeWidth="0"
-          >
-            <tspan y="0" fontWeight="700" strokeWidth="0">
-              A16
-            </tspan>
-          </text>
+          <RoomText x={635} y={165} lineHeight={15} fontSize={25} lines={[ { text: 'A16' }, ]} />
         </g>
         {/* A15 */}
         <g style={getRoomStyle('classroom', isSelected('AN3-A15'), hasSelection)}
@@ -182,19 +159,7 @@ export default function AularioNave3PlantaBaja({ selectedCode, handleOpen }: Aul
             d="M737.789297,39.238172h327.800168v189.225749l-327.800168-.428984v-188.796765Z"
             transform="translate(.000001 0.000001)"
           />
-          <text
-            dx="0"
-            dy="0"
-            fontFamily='"eBHsLTiXjpU1:::Roboto"'
-            fontSize="25"
-            fontWeight="400"
-            transform="translate(895 140)"
-            strokeWidth="0"
-          >
-            <tspan y="0" fontWeight="700" strokeWidth="0">
-              A15
-            </tspan>
-          </text>
+          <RoomText x={895} y={140} lineHeight={15} fontSize={25} lines={[ { text: 'A15' }, ]} />
         </g>
         {/* Baños */}
         <g
@@ -208,35 +173,14 @@ export default function AularioNave3PlantaBaja({ selectedCode, handleOpen }: Aul
             d="M296.26254,82.149783h53.518396v101.936404h-53.518396v-101.936404Z"
             transform="translate(.000002 0.000003)"
           />
-          <text
-            dx="0"
-            dy="0"
-            fontFamily='"eBHsLTiXjpU1:::Roboto"'
-            fontSize="25"
-            fontWeight="400"
-            transform="translate(300 109)"
-            strokeWidth="0"
-          >
-            <tspan x="0" y="0" fontWeight="700" strokeWidth="0">
-              B
-            </tspan>
-            <tspan x="0" y="16" fontWeight="700" strokeWidth="0">
-              a
-            </tspan>
-            <tspan x="0" y="36" fontWeight="700" strokeWidth="0">
-              ñ
-            </tspan>
-            <tspan x="0" y="52" fontWeight="700" strokeWidth="0">
-              o
-            </tspan>
-            <tspan x="0" y="68" fontWeight="700" strokeWidth="0">
-              s
-            </tspan>
-          </text>
+          <RoomText x={300} y={109} lineHeight={16} fontSize={25} 
+          lines={[ { text: 'B' }, { text: 'a' } ]} />
+          <RoomText x={300} y={145} lineHeight={16} fontSize={25} 
+          lines={[ { text: 'ñ' }, { text: 'o' } , { text: 's' } ]} />
           <Toilet
             /* transform="translate(315 115)" */
             x="320"
-            y="90"
+            y="115"
             className="icon-common"
             size={30}
           />

--- a/src/components/common/map/its/ITSPb.tsx
+++ b/src/components/common/map/its/ITSPb.tsx
@@ -1,5 +1,6 @@
 import { CaretCircleUpDown, Toilet } from '@phosphor-icons/react'
 import { mapColors } from '../../../pages/map/mapColors'
+import { getRoomStyle } from '../RoomStyle'
 
 interface ITSPbProps {
   selectedCode?: string // Cambiado de selectedClassRoomId
@@ -9,6 +10,7 @@ interface ITSPbProps {
 
 export default function ITSPb({selectedCode,handleOpen}: ITSPbProps) {
   const isSelected = (id: string) => id === selectedCode
+    const hasSelection = !!selectedCode   //convierte selectedCode a boolean
 
   return (
     <>
@@ -103,7 +105,8 @@ export default function ITSPb({selectedCode,handleOpen}: ITSPbProps) {
           </g>
           {/*.......................................................:Aulas:...........................................................*/}
           {/* Aula 1*/}
-          <g onClick={() => handleOpen?.('ITS-A1')}
+          <g style={getRoomStyle('classroom', isSelected('ITS-A1'), hasSelection)}
+            onClick={() => handleOpen?.('ITS-A1')}
             className={`classRoom ${isSelected('ITS-A1') ? 'selected' : ''}`}>
             <path d="M154.773811,447.647782v76.993416h107.493282v-76.993416h-107.493282Z" transform="matrix(0.98668 0 0 1.335732 -152.616153 -484.823892)"/>
             <text dx="0" dy="0" fontFamily='"eBHsLTiXjpU1:::Roboto"' fontSize="12" fontWeight="400" strokeWidth="0"
@@ -114,7 +117,8 @@ export default function ITSPb({selectedCode,handleOpen}: ITSPbProps) {
             </text>
           </g>
           {/* Aula 2*/}
-          <g onClick={() => handleOpen?.('ITS-A2')}
+          <g style={getRoomStyle('lab', isSelected('ITS-A2'), hasSelection)}
+            onClick={() => handleOpen?.('ITS-A2')}
             className={`classRoom ${isSelected('ITS-A2') ? 'selected' : ''}`}>
             <path d="M154.773811,447.647782v76.993416h107.493282v-76.993416h-107.493282Z" transform="matrix(0.984893 0 0 1.335732 -152.339548 -381.981322)"/>
             <text dx="0" dy="0" fontFamily='"eBHsLTiXjpU1:::Roboto"' fontSize="12" fontWeight="400" strokeWidth="0"
@@ -125,7 +129,8 @@ export default function ITSPb({selectedCode,handleOpen}: ITSPbProps) {
             </text>
           </g>
           {/* Aula 3*/}
-          <g onClick={() => handleOpen?.('ITS-A3')}
+          <g style={getRoomStyle('lab', isSelected('ITS-A3'), hasSelection)}
+            onClick={() => handleOpen?.('ITS-A3')}
             className={`classRoom ${isSelected('ITS-A3') ? 'selected' : ''}`}>
             <path d="M154.773811,447.647782v76.993416h107.493282v-76.993416h-107.493282Z" transform="matrix(0.984881 0 0 1.335732 -152.336401 -279.138752)"/>
             <text dx="0" dy="0" fontFamily='"eBHsLTiXjpU1:::Roboto"' fontSize="12" fontWeight="400" strokeWidth="0"
@@ -136,7 +141,8 @@ export default function ITSPb({selectedCode,handleOpen}: ITSPbProps) {
             </text>
           </g>
           {/* Aula 4*/}
-          <g onClick={() => handleOpen?.('ITS-A4')}
+          <g  style={getRoomStyle('classroom', isSelected('ITS-A4'), hasSelection)}
+            onClick={() => handleOpen?.('ITS-A4')}
             className={`classRoom ${isSelected('ITS-A4') ? 'selected' : ''}`}>
             <path d="M154.428424,447.647782l.000001,76.993416h106.484852l1.008429-76.993416h-107.493282Z" transform="matrix(0.986682 0 0 1.339819 -152.371803 -178.125711)"/>
             <text dx="0" dy="0" fontFamily='"eBHsLTiXjpU1:::Roboto"' fontSize="12" fontWeight="400" strokeWidth="0"

--- a/src/components/common/map/tornavias/TornaviasPlantaBaja.tsx
+++ b/src/components/common/map/tornavias/TornaviasPlantaBaja.tsx
@@ -1,6 +1,7 @@
 import { Toilet, File, BookOpenText, ForkKnife, CaretCircleUpDown } from '@phosphor-icons/react'
 import { mapColors } from '../../../pages/map/mapColors'
 import { getRoomStyle } from '../RoomStyle'
+import { getMapStyle } from '../MapStyle'
 
 interface TornaviasPlantaBajaProps {
   selectedCode?: string // Cambiado de selectedClassRoomId
@@ -1283,8 +1284,7 @@ export default function TornaviasPlantaBaja({ selectedCode, handleOpen }: Tornav
         {/* Ingeniería en Energía */}
         <g style={getRoomStyle('lab', isSelected('TOR-IEN'), hasSelection)}
           onClick={() => handleOpen?.('TOR-IEN')}
-          className={`classRoom ${isSelected('TOR-IEN') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-IEN') ? 'selected' : ''}`}>
           <path d="M549.169254,575.385776c7.898751-4.666319,19.759674-13.837344,24.26661-17.77757l34.460785,41.641804c-8.888181,7.251522-23.190236,18.453662-30.578996,21.745986" />
           <text
             dx="0"
@@ -1364,13 +1364,7 @@ export default function TornaviasPlantaBaja({ selectedCode, handleOpen }: Tornav
         </g>
         {/* ..................................AyP //! Hay que actualizar los datos de la sección de ex-Humanidades */}
         {/* Sala de Prof AyP */}
-        <g
-          style={{
-            fill: mapColors.humanidades.fill,
-            stroke: mapColors.humanidades.stroke,
-            strokeWidth: mapColors.humanidades.strokeWidth
-          }}
-        >
+        <g style={getMapStyle( mapColors.humanidades, hasSelection )} >
           <path
             d="M525.112846,190.449754l30.809784,14.566452l16.085864-28.032859c-7.029046-5.013683-24.83861-13.608648-35.213244-16.624776l-11.682404,30.091183Z"
             transform="translate(.000004 0.000001)"
@@ -1393,13 +1387,7 @@ export default function TornaviasPlantaBaja({ selectedCode, handleOpen }: Tornav
           </text>
         </g>
         {/* Departamento de servicios académicos EH */}
-        <g
-          style={{
-            fill: mapColors.humanidades.fill,
-            stroke: mapColors.humanidades.stroke,
-            strokeWidth: mapColors.humanidades.strokeWidth
-          }}
-        >
+        <g style={getMapStyle( mapColors.humanidades, hasSelection )} >
           <path
             d="M459.017196,142.982326c-11.98079-.941199-31.695726-.447048-40.60859.534947l4.860879,54.315229c8.598158-.948591,24.775352-1.450442,32.632527-.478327l3.115184-54.371849Z"
             transform="translate(0 0.000003)"
@@ -1425,15 +1413,9 @@ export default function TornaviasPlantaBaja({ selectedCode, handleOpen }: Tornav
           </text>
         </g>
         {/* Cámara Gesell*/}
-        <g
-          style={{
-            fill: mapColors.humanidades.fill,
-            stroke: mapColors.humanidades.stroke,
-            strokeWidth: mapColors.humanidades.strokeWidth
-          }}
+        <g style={getRoomStyle('lab_h', isSelected('TOR-CG'), hasSelection)}
           onClick={() => handleOpen?.('TOR-CG')}
-          className={`classRoom ${isSelected('TOR-CG') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-CG') ? 'selected' : ''}`}>
           <path
             d="M418.408606,143.517274c-8.253008.539874-26.610644,3.298821-38.512331,6.416424l13.919479,52.79692c7.804107-2.107954,22.325769-4.690337,29.453731-4.898115"
             transform="translate(0 0.000002)"
@@ -1457,13 +1439,7 @@ export default function TornaviasPlantaBaja({ selectedCode, handleOpen }: Tornav
         </g>
         {/* ..........................................:Consultorías:.......................................... */}
         {/* Información estudiantil */}
-        <g
-          style={{
-            fill: mapColors.consultancy.fill,
-            stroke: mapColors.consultancy.stroke,
-            strokeWidth: mapColors.consultancy.strokeWidth
-          }}
-        >
+        <g style={getMapStyle( mapColors.consultancy, hasSelection )}>
           <path
             d="M611.255379,249.956345l22.912717-21.057066c-5.249803-6.594222-18.944855-19.660462-27.191123-26.168659l-20.500679,24.569214l24.779085,22.656511Z"
             transform="translate(.000002 0.000003)"
@@ -1487,13 +1463,7 @@ export default function TornaviasPlantaBaja({ selectedCode, handleOpen }: Tornav
         </g>
         {/* Becas Unsam o algo así  */}
         {/* //todo: Fijarse el nombre de esta aula.... lo cambiaron hace poco */}
-        <g
-          style={{
-            fill: mapColors.consultancy.fill,
-            stroke: mapColors.consultancy.stroke,
-            strokeWidth: mapColors.consultancy.strokeWidth
-          }}
-        >
+        <g style={getMapStyle( mapColors.consultancy, hasSelection )}>
           <path
             d="M617.136611,504.764578c4.524517-7.497886,11.742026-22.010435,14.308387-29.018766l50.42274,19.884001c-2.903436,8.247081-12.515773,26.58666-18.631011,36.679158l-46.100116-27.544393Z"
             transform="translate(.000003 0)"
@@ -1516,13 +1486,7 @@ export default function TornaviasPlantaBaja({ selectedCode, handleOpen }: Tornav
           </text>
         </g>
         {/* Punto Bienestar */}
-        <g
-          style={{
-            fill: mapColors.consultancy.fill,
-            stroke: mapColors.consultancy.stroke,
-            strokeWidth: mapColors.consultancy.strokeWidth
-          }}
-        >
+        <g style={getMapStyle( mapColors.consultancy, hasSelection )}>
           <path
             d="M330.122037,695.331971c11.404956,4.134074,33.007349,11.189303,43.357359,13.332271l-12.089435,52.349969c-8.548164-2.158496-24.903146-5.585735-50.63911-16.622549l19.371186-49.059691Z"
             transform="translate(.000002 0.000002)"
@@ -1764,8 +1728,9 @@ export default function TornaviasPlantaBaja({ selectedCode, handleOpen }: Tornav
               </tspan>
             </text>
           </g>
-          {/* Limpieza */}
-          <g>
+        </g>
+        {/* Limpieza */}
+          <g style={getMapStyle( mapColors.banios, hasSelection )}>
             <path
               d="M545.398145,700.77347c8.721971-2.993329,19.984774-8.696205,23.225983-10.154164l21.527653,49.211442c-2.752341,1.595955-14.168785,5.958494-27.59247,10.07287L545.398145,700.77347Z"
               transform="translate(.000001 0)"
@@ -1784,7 +1749,6 @@ export default function TornaviasPlantaBaja({ selectedCode, handleOpen }: Tornav
               </tspan>
             </text>
           </g>
-        </g>
       </svg>
     </>
   )

--- a/src/components/common/map/tornavias/TornaviasPlantaBaja.tsx
+++ b/src/components/common/map/tornavias/TornaviasPlantaBaja.tsx
@@ -1,5 +1,6 @@
 import { Toilet, File, BookOpenText, ForkKnife, CaretCircleUpDown } from '@phosphor-icons/react'
 import { mapColors } from '../../../pages/map/mapColors'
+import { getRoomStyle } from '../RoomStyle'
 
 interface TornaviasPlantaBajaProps {
   selectedCode?: string // Cambiado de selectedClassRoomId
@@ -7,11 +8,10 @@ interface TornaviasPlantaBajaProps {
   handleOpen?: (classRoomId: string) => void
 }
 
-export default function TornaviasPlantaBaja({
-  selectedCode,
-  handleOpen
-}: TornaviasPlantaBajaProps) {
+export default function TornaviasPlantaBaja({ selectedCode, handleOpen }: TornaviasPlantaBajaProps) {
   const isSelected = (id: string) => id === selectedCode
+  const hasSelection = !!selectedCode //convierte selectedCode a boolean
+
   return (
     <>
       <svg
@@ -492,15 +492,9 @@ export default function TornaviasPlantaBaja({
         </g>
         {/* .......................................................:Aulas:......................................................... */}
         {/* A1 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A1'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A1')}
-          className={`classRoom ${isSelected('TOR-A1') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A1') ? 'selected' : ''}`} >
           <path
             d="M512.928028,93.672453c11.944716,2.700362,33.777158,9.044196,43.752717,12.656299l18.764596-50.127411c-8.200311-4.278074-34.013126-11.725643-50.332496-15.637496L512.928028,93.672453Z"
             transform="translate(.000001 0.000001)"
@@ -520,15 +514,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A2 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A2'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A2')}
-          className={`classRoom ${isSelected('TOR-A2') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A2') ? 'selected' : ''}`} >
           <path
             d="M500.31631,149.081046c7.487088,1.447509,23.304624,6.225106,36.478944,11.277523l-20.054092,50.364672c-6.084496-2.321571-20.384546-6.492754-28.453168-8.526029l12.028316-53.116166Z"
             transform="translate(0 0.000003)"
@@ -548,15 +536,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A3 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A3'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A3')}
-          className={`classRoom ${isSelected('TOR-A3') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A3') ? 'selected' : ''}`} >
           <path
             d="M462.940163,86.346184c13.500263.914865,38.542423,4.508335,49.987862,7.326267l12.184821-53.108607c-12.061925-4.018794-41.301389-8.09695-58.770125-8.507654l-3.402558,54.289994Z"
             transform="translate(.000003 0.000002)"
@@ -576,15 +558,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A4 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A4'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A4')}
-          className={`classRoom ${isSelected('TOR-A4') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A4') ? 'selected' : ''}`} >
           <path
             d="M488.287993,202.197212l12.028315-53.116164c-8.528883-2.155273-29.141575-5.194721-41.299114-6.09872l-3.115184,54.371848c8.891574.462243,25.003016,2.993172,32.385983,4.843036Z"
             transform="translate(.000002 0.000001)"
@@ -604,15 +580,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A5 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A5'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A5')}
-          className={`classRoom ${isSelected('TOR-A5') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A5') ? 'selected' : ''}`} >
           <path
             d="M414.02035,87.281622c15.191994-1.305193,39.09013-1.427763,48.919812-.935439l3.402561-54.289992c-9.272594-1.564911-38.654138.022679-57.683908,1.256636l5.361535,53.968795Z"
             transform="translate(.000001 0.000001)"
@@ -632,15 +602,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A6 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A6'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A6')}
-          className={`classRoom ${isSelected('TOR-A6') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A6') ? 'selected' : ''}`} >
           <path
             d="M319.565748,111.604373c5.835238-2.746279,17.436838-7.337733,23.233501-9.336112L325.27775,51.909095c-7.582971,2.530409-21.144366,7.63813-27.080693,10.468016l21.368691,49.227262Z"
             transform="translate(.000002 0.000002)"
@@ -660,15 +624,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A6 BIS */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A6BIS'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A6BIS')}
-          className={`classRoom ${isSelected('TOR-A6BIS') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A6BIS') ? 'selected' : ''}`} >
           <path
             d="M342.799247,102.268263c6.875444-2.239378,18.985974-6.002836,24.402775-7.43606L353.61515,42.803115c-6.272459,1.739658-20.398462,6.360967-28.337402,9.105982l17.521499,50.359166Z"
             transform="translate(.000004 0)"
@@ -691,15 +649,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A7 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A7'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A7')}
-          className={`classRoom ${isSelected('TOR-A7') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A7') ? 'selected' : ''}`} >
           <path d="M367.202026,94.832203c12.128687-3.332884,35.343102-6.854257,46.818324-7.550581l-5.361534-53.968794c-15.444814.626046-42.958866,4.702859-55.043662,9.490287l13.586872,52.029088Z" />
           <text
             dx="0"
@@ -716,15 +668,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A8 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A8'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A8')}
-          className={`classRoom ${isSelected('TOR-A8') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A8') ? 'selected' : ''}`} >
           <path d="M274.022341,206.945029l36.421292,39.43539c12.009296-11.719406,39.171505-28.241097,52.284151-33.101789l-21.052872-49.627238c-20.489948,7.526624-54.173738,29.397889-67.652571,43.293637Z" />
           <text
             dx="0"
@@ -741,15 +687,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A9 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A9'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A9')}
-          className={`classRoom ${isSelected('TOR-A9') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A9') ? 'selected' : ''}`} >
           <path
             d="M678.508829,300.299481c-6.750477-18.250848-28.604657-53.927891-44.340733-71.400199l-40.215014,36.675111c14.542258,16.666771,32.101285,46.469553,35.759525,56.169205l48.796222-21.444117Z"
             transform="translate(.000004 0.000002)"
@@ -769,15 +709,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A10 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A10'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A10')}
-          className={`classRoom ${isSelected('TOR-A10') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A10') ? 'selected' : ''}`} >
           <path
             d="M644.09529,382.015267c-1.143131-16.660468-7.247018-46.999495-14.38268-60.27167l48.796222-21.444117c8.528969,16.897166,16.931624,55.142991,19.204673,76.566629q-53.618214,5.14916-53.618215,5.149158Z"
             transform="translate(.000001 0.000003)"
@@ -797,15 +731,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A11 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A11'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A11')}
-          className={`classRoom ${isSelected('TOR-A11') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A11') ? 'selected' : ''}`} >
           <path
             d="M678.508834,607.669105c10.83975-11.924186,26.232385-34.621776,32.556889-46.200462l46.020955,27.564616c-8.038058,15.057455-29.171153,41.719859-38.637724,53.513214l-39.94012-34.877368Z"
             transform="translate(.000001 0)"
@@ -825,15 +753,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A12 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A12'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A12')}
-          className={`classRoom ${isSelected('TOR-A12') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A12') ? 'selected' : ''}`} >
           <path
             d="M644.095295,642.546472c10.865644-10.141861,28.540689-27.642982,34.413538-34.877368l39.940122,34.877366c-8.605296,10.437152-28.384119,30.520616-39.940121,40.166927l-34.413539-40.166925Z"
             transform="translate(0 0.000001)"
@@ -853,15 +775,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A13 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A13'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A13')}
-          className={`classRoom ${isSelected('TOR-A13') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A13') ? 'selected' : ''}`} >
           <path
             d="M606.976976,669.871815c9.99314-5.75313,27.663689-19.641026,37.118317-27.325345l34.413539,40.166925c-9.094788,8.601062-31.479735,24.638633-44.340732,32.743725l-27.191124-45.585305Z"
             transform="translate(.000002 0.000002)"
@@ -881,15 +797,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A14 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A14'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A14')}
-          className={`classRoom ${isSelected('TOR-A14') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A14') ? 'selected' : ''}`} >
           <path
             d="M568.624129,690.619306c9.952047-4.587485,29.083602-14.993279,38.352847-20.747493l27.191125,45.585307c-8.810896,5.985619-30.994482,17.909293-44.016319,24.373626l-21.527653-49.21144Z"
             transform="translate(0 0.000002)"
@@ -909,15 +819,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A15 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A15'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A15')}
-          className={`classRoom ${isSelected('TOR-A15') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A15') ? 'selected' : ''}`} >
           <path
             d="M617.136608,504.764575l46.100119,27.544393c-7.646298,13.91578-34.708485,48.088947-55.340079,66.941042l-34.460787-41.641807c15.506934-14.894561,38.840897-40.351288,43.700747-52.843628Z"
             transform="translate(.000003 0.000003)"
@@ -937,15 +841,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A16 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A16'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A16')}
-          className={`classRoom ${isSelected('TOR-A16') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A16') ? 'selected' : ''}`} >
           <path
             d="M546.215801,638.271223c4.743694-1.705548,15.928883-7.090259,31.101849-17.275224l-28.148399-45.610223c-5.938943,3.846215-18.418792,10.238881-24.943969,12.838807l21.990519,50.04664Z"
             transform="translate(.000003 0)"
@@ -965,15 +863,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A17 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A17'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A17')}
-          className={`classRoom ${isSelected('TOR-A17') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A17') ? 'selected' : ''}`} >
           <path d="M506.683509,651.420698c12.746688-3.315106,33.15614-9.511429,39.532292-13.149475l-21.990516-50.04664c-6.930454,3.36937-21.745469,8.808824-30.377302,11.025427l12.835526,52.170688Z" />
           <text
             dx="0"
@@ -990,15 +882,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A18 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A18'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A18')}
-          className={`classRoom ${isSelected('TOR-A18') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A18') ? 'selected' : ''}`} >
           <path
             d="M350.016558,641.5878c-21.031572-9.02946-55.435434-28.160415-67.135151-40.127471l32.492885-42.731182c14.19937,12.084084,40.952526,29.634505,53.343151,32.309266L350.016558,641.5878Z"
             transform="translate(.000003 0)"
@@ -1018,15 +904,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A19 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A19'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A19')}
-          className={`classRoom ${isSelected('TOR-A19') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A19') ? 'selected' : ''}`} >
           <path
             d="M273.111053,512.080725c7.415474,13.710616,29.198574,36.776487,42.263239,46.648422l-32.492883,42.731182c-16.481705-10.310838-41.869802-41.583753-54.170306-60.848775l44.39995-28.530829Z"
             transform="translate(.000003 0)"
@@ -1046,15 +926,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A20 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A20'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A20')}
-          className={`classRoom ${isSelected('TOR-A20') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A20') ? 'selected' : ''}`} >
           <path
             d="M196.602536,465.685617l50.865693-12.175648c1.435027,6.533366,6.728039,20.357491,10.107866,28.166256l-48.033844,21.352206c-5.056943-8.523918-11.310316-27.238622-12.939715-37.342814Z"
             transform="translate(.000003 0.000002)"
@@ -1074,15 +948,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A21 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A21'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A21')}
-          className={`classRoom ${isSelected('TOR-A21') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A21') ? 'selected' : ''}`} >
           <path
             d="M330.122036,695.331972c-22.285376-7.317999-63.381103-32.18658-82.6538-48.795675l-33.578057,41.01391c18.882655,17.399928,68.1131,44.809819,96.860671,56.841456l19.371186-49.059691Z"
             transform="translate(.000003 0.000001)"
@@ -1102,15 +970,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A22 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A22'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A22')}
-          className={`classRoom ${isSelected('TOR-A22') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A22') ? 'selected' : ''}`} >
           <path
             d="M213.890178,687.550207l33.578054-41.013909c-11.556562-9.838524-28.950623-26.267106-35.213015-34.320464l-38.31775,35.937731c8.938435,10.011457,28.902021,29.599324,39.952711,39.396642Z"
             transform="translate(.000002 0.000001)"
@@ -1130,15 +992,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A23 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A23'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A23')}
-          className={`classRoom ${isSelected('TOR-A23') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A23') ? 'selected' : ''}`} >
           <path
             d="M173.937466,648.153564l38.317752-35.937731c-9.149931-9.618086-25.062728-30.766437-31.832377-42.291372l-44.224124,29.325548c6.823715,11.321972,25.667713,35.145244,37.738749,48.903555"
             transform="translate(.000001 0.000002)"
@@ -1158,15 +1014,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* A24 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A24'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A24')}
-          className={`classRoom ${isSelected('TOR-A24') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A24') ? 'selected' : ''}`} >
           <path
             d="M180.422842,569.924463c-6.675661-9.907866-18.062322-31.719714-23.152769-43.393871l-47.953242,20.965115c5.261847,12.984189,18.343033,39.000345,26.881885,51.754301l44.224126-29.325545Z"
             transform="translate(.000003 0.000002)"
@@ -1186,15 +1036,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* T02 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-T02'), hasSelection)}
           onClick={() => handleOpen?.('TOR-T02')}
-          className={`classRoom ${isSelected('TOR-T02') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-T02') ? 'selected' : ''}`} >
           <path 
             d="M193.081265,337.040194l37.621152,8.768888c-.444433,8.574659-4.023992,29.358207-3.371608,53.987308.641513,24.218685,3.174903,51.386761,6.204342,60.114494l-38.110792,8.605507c0,0-6.192266-30.878079-7.028844-63.124789-.867736-33.447721,3.637227-68.30874,4.68575-68.351408Z" 
             transform="matrix(1.336062-.027544 0.02583 1.252917-182.263316-88.960178)"
@@ -1214,15 +1058,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* T01 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-T01'), hasSelection)}
           onClick={() => handleOpen?.('TOR-T01')}
-          className={`classRoom ${isSelected('TOR-T01') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-T01') ? 'selected' : ''}`} >
           <path 
             d="M196.60254,465.685622l50.865692-12.175651c-9.214473-23.830131-8.10238-73.480939-2.042407-98.684328l-49.816977-9.13175c-7.254887,31.549944-8.404497,91.491921.993692,119.991729Z" 
             transform="translate(0 0.000001)"
@@ -1243,15 +1081,9 @@ export default function TornaviasPlantaBaja({
         </g>
         {/* .......................................................:Laboratorios:......................................................................................... */}
         {/* Laboratorio de Física */}
-        <g
-          style={{
-            fill: mapColors.lab.fill,
-            stroke: mapColors.lab.stroke,
-            strokeWidth: mapColors.lab.strokeWidth
-          }}
+        <g style={getRoomStyle('lab', isSelected('TOR-LF'), hasSelection)}
           onClick={() => handleOpen?.('TOR-LF')}
-          className={`classRoom ${isSelected('TOR-LF') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-LF') ? 'selected' : ''}`} >
           <path d="M644.09529,382.015267l53.618216-5.149157c1.870369,18.730835-1.177904,58.107014-5.036627,78.911346l-52.049281-12.019333c4.238038-13.417239,4.905592-44.175459,3.467692-61.742856Z" />
           <text
             dx="0"
@@ -1271,15 +1103,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* Laboratorio de Química */}
-        <g
-          style={{
-            fill: mapColors.lab.fill,
-            stroke: mapColors.lab.stroke,
-            strokeWidth: mapColors.lab.strokeWidth
-          }}
+        <g style={getRoomStyle('lab', isSelected('TOR-LQ'), hasSelection)}
           onClick={() => handleOpen?.('TOR-LQ')}
-          className={`classRoom ${isSelected('TOR-LQ') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-LQ') ? 'selected' : ''}`} >
           <path
             d="M729.848675,278.040692l48.94499-20.837043c-9.462383-25.487248-39.384806-77.18636-63.413498-101.97265l-39.715411,35.671472c19.331483,21.545873,46.764892,65.068423,54.183919,87.138221Z"
             transform="translate(.000003 0)"
@@ -1302,15 +1128,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* Laboratorio de Biología */}
-        <g
-          style={{
-            fill: mapColors.lab.fill,
-            stroke: mapColors.lab.stroke,
-            strokeWidth: mapColors.lab.strokeWidth
-          }}
+        <g style={getRoomStyle('lab', isSelected('TOR-LB'), hasSelection)}
           onClick={() => handleOpen?.('TOR-LB')}
-          className={`classRoom ${isSelected('TOR-LB') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-LB') ? 'selected' : ''}`} >
           <path d="M746.031684,326.011547l51.308606-12.619248c-2.866748-11.853755-11.084149-40.174065-18.546625-56.18865l-48.944987,20.837043c4.31331,8.225915,11.748444,32.619197,16.183006,47.970855Z" />
           <text
             dx="0"
@@ -1330,15 +1150,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* Laboratorio de Biología */}
-        <g
-          style={{
-            fill: mapColors.lab.fill,
-            stroke: mapColors.lab.stroke,
-            strokeWidth: mapColors.lab.strokeWidth
-          }}
+        <g style={getRoomStyle('lab', isSelected('TOR-LB'), hasSelection)}
           onClick={() => handleOpen?.('TOR-LB')}
-          className={`classRoom ${isSelected('TOR-LB') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-LB') ? 'selected' : ''}`} >
           <path
             d="M753.495865,371.627002l52.786904-4.576492c-1.383803-13.661818-4.626156-40.553235-8.942481-53.658211l-51.308606,12.619245c3.302905,11.848883,6.68986,34.641635,7.464183,45.615458Z"
             transform="translate(.000002 0.000003)"
@@ -1361,15 +1175,9 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* Laboratorio de Neuroingeniería */}
-        <g
-          style={{
-            fill: mapColors.lab.fill,
-            stroke: mapColors.lab.stroke,
-            strokeWidth: mapColors.lab.strokeWidth
-          }}
+        <g style={getRoomStyle('lab', isSelected('TOR-LN'), hasSelection)}
           onClick={() => handleOpen?.('TOR-LN')}
-          className={`classRoom ${isSelected('TOR-LN') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-LN') ? 'selected' : ''}`} >
           <path
             d="M753.495866,420.365744c.866196-11.731911,1.126698-36.204853,0-48.738742l52.786903-4.576493c1.894257,10.955076,1.385946,39.068081.671495,56.479143l-53.458398-3.163908Z"
             transform="translate(.000001 0.000003)"
@@ -1392,12 +1200,7 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* Laboratorio de Electrónica II*/}
-        <g
-          style={{
-            fill: mapColors.lab.fill,
-            stroke: mapColors.lab.stroke,
-            strokeWidth: mapColors.lab.strokeWidth
-          }}
+        <g style={getRoomStyle('lab', isSelected('TOR-LE2'), hasSelection)}
           onClick={() => handleOpen?.('TOR-LE2')}
           className={`classRoom ${isSelected('TOR-LE2') ? 'selected' : ''}`}
         >
@@ -1426,12 +1229,7 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* Laboratorio de Termodinámica*/}{' '}
-        <g
-          style={{
-            fill: mapColors.lab.fill,
-            stroke: mapColors.lab.stroke,
-            strokeWidth: mapColors.lab.strokeWidth
-          }}
+        <g style={getRoomStyle('lab', isSelected('TOR-LT'), hasSelection)}
           onClick={() => handleOpen?.('TOR-LT')}
           className={`classRoom ${isSelected('TOR-LT') ? 'selected' : ''}`}
         >
@@ -1457,12 +1255,7 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* Laboratorio de Computación IV */}
-        <g
-          style={{
-            fill: mapColors.lab.fill,
-            stroke: mapColors.lab.stroke,
-            strokeWidth: mapColors.lab.strokeWidth
-          }}
+        <g style={getRoomStyle('lab', isSelected('TOR-LC4'), hasSelection)}
           onClick={() => handleOpen?.('TOR-LC4')}
           className={`classRoom ${isSelected('TOR-LC4') ? 'selected' : ''}`}
         >
@@ -1488,12 +1281,7 @@ export default function TornaviasPlantaBaja({
           </text>
         </g>
         {/* Ingeniería en Energía */}
-        <g
-          style={{
-            fill: mapColors.lab.fill,
-            stroke: mapColors.lab.stroke,
-            strokeWidth: mapColors.lab.strokeWidth
-          }}
+        <g style={getRoomStyle('lab', isSelected('TOR-IEN'), hasSelection)}
           onClick={() => handleOpen?.('TOR-IEN')}
           className={`classRoom ${isSelected('TOR-IEN') ? 'selected' : ''}`}
         >

--- a/src/components/common/map/tornavias/TornaviasPrimerPiso.tsx
+++ b/src/components/common/map/tornavias/TornaviasPrimerPiso.tsx
@@ -2,6 +2,7 @@ import { BookOpenText, CaretCircleUpDown, ForkKnife, Toilet } from '@phosphor-ic
 import { mapColors } from '../../../pages/map/mapColors'
 import RoomText from '../RoomText'
 import { getRoomStyle } from '../RoomStyle'
+import { getMapStyle } from '../MapStyle'
 
 interface TornaviasPrimerPisoProps {
   selectedCode?: string // Cambiado de selectedClassRoomId
@@ -491,13 +492,7 @@ export default function TornaviasPrimerPiso({ selectedCode, handleOpen }: Tornav
         </g>
         {/* .....................................:Escuela de Ciencia y Tecnología:........................................................ */}
         {/* Ecyt Decanato */}
-        <g
-          style={{
-            fill: mapColors.escuelaCyt.fill,
-            stroke: mapColors.escuelaCyt.stroke,
-            strokeWidth: mapColors.escuelaCyt.strokeWidth
-          }}
-        >
+        <g style={getMapStyle( mapColors.escuelaCyt, hasSelection )}>
           <path
             d="M757.760344,419.902162c2.008742-22.670625-2.526518-75.058429-10.989724-105.113442-6.74222-30.964592-39.239565-92.6416-65.560797-122.367408l39.061306-34.540929c33.301992,34.547907,65.020307,90.654422,78.984958,148.918585c10.03177,33.294534,12.601966,76.997017,11.57922,116.73559l-53.074963-3.632396Z"
             transform="translate(.000001 0.000005)"
@@ -511,13 +506,7 @@ export default function TornaviasPrimerPiso({ selectedCode, handleOpen }: Tornav
           />
         </g>
         {/* Alumnos */}
-        <g
-          style={{
-            fill: mapColors.escuelaCyt.fill,
-            stroke: mapColors.escuelaCyt.stroke,
-            strokeWidth: mapColors.escuelaCyt.strokeWidth
-          }}
-        >
+        <g style={getMapStyle( mapColors.escuelaCyt, hasSelection )}>
           <path
             d="M646.970343,314.108769l34.239481-14.591046c3.972581,8.543808,10.270582,26.74574,12.876093,36.403864l-36.56069,8.680129c-2.411722-6.579224-6.865825-22.142615-10.554884-30.492947Z"
             transform="translate(.000001 0.000002)"
@@ -531,15 +520,9 @@ export default function TornaviasPrimerPiso({ selectedCode, handleOpen }: Tornav
           />
         </g>
         {/* Instituto Colomb */}
-        <g
-          style={{
-            fill: mapColors.escuelaCyt.fill,
-            stroke: mapColors.escuelaCyt.stroke,
-            strokeWidth: mapColors.escuelaCyt.strokeWidth
-          }}
+        <g style={getRoomStyle('eCyT', isSelected('IC'), hasSelection)}
           onClick={() => handleOpen?.('IC')}
-          className={`classRoom ${isSelected('IC') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('IC') ? 'selected' : ''}`}>
           <path
             d="M589.265362,565.005193l23.788344,28.230525c-13.601894,12.714696-46.693126,33.629922-65.911393,42.136836l-14.421822-33.78161c15.985983-6.49366,44.071082-25.056245,56.544871-36.585751Z"
             transform="translate(.000002 0)"
@@ -554,13 +537,7 @@ export default function TornaviasPrimerPiso({ selectedCode, handleOpen }: Tornav
           />
         </g>
         {/* Sala de profesores Cyt */}
-        <g
-          style={{
-            fill: mapColors.escuelaCyt.fill,
-            stroke: mapColors.escuelaCyt.stroke,
-            strokeWidth: mapColors.escuelaCyt.strokeWidth
-          }}
-        >
+        <g style={getMapStyle( mapColors.escuelaCyt, hasSelection )}>
           <path d="M613.937146,540.085921l-24.671782,24.919272l17.225526,20.438799l28.450627-28.45947-21.004371-16.898601Z" />
           <RoomText
             x={600} y={570}
@@ -617,13 +594,7 @@ export default function TornaviasPrimerPiso({ selectedCode, handleOpen }: Tornav
           />
         </g>
         {/* OSUNSAM */}
-        <g
-          style={{
-            fill: mapColors.commonAreas.fill,
-            stroke: mapColors.commonAreas.stroke,
-            strokeWidth: mapColors.commonAreas.strokeWidth
-          }}
-        >
+        <g style={getMapStyle( mapColors.commonAreas, hasSelection )}>
           <path
             d="M259.381702,519.189596c10.935457,15.841837,34.929202,41.640842,48.261207,51.125226l-24.869613,29.443841c-12.782995-10.876047-40.871718-40.026007-53.624121-59.672745l30.232527-20.896322Z"
             transform="translate(.000004 0.000003)"
@@ -638,13 +609,7 @@ export default function TornaviasPrimerPiso({ selectedCode, handleOpen }: Tornav
         </g>
         {/* ..............................................:IAMK:............................................................... */}
         {/* IECJ IAMK Administración */}
-        <g
-          style={{
-            fill: mapColors.iAMK.fill,
-            stroke: mapColors.iAMK.stroke,
-            strokeWidth: mapColors.iAMK.strokeWidth
-          }}
-        >
+        <g style={getMapStyle( mapColors.iAMK, hasSelection )}>
           <path
             d="M234.730854,633.622503c-7.380325-6.56406-19.527527-19.227165-24.388226-25.772566l-40.138234,36.763466c5.856737,8.003894,20.655397,22.143183,28.403533,28.551429l36.122927-39.542329Z"
             transform="translate(.000001 0.000002)"
@@ -664,12 +629,7 @@ export default function TornaviasPrimerPiso({ selectedCode, handleOpen }: Tornav
         </g>
         {/* .................................................:Instituto Transporte IT:.................................................................................................................... */}
         {/* Instituto de Transporte IT */}
-        <g
-          style={{
-            fill: mapColors.institutoTransporte.fill,
-            stroke: mapColors.institutoTransporte.stroke,
-            strokeWidth: mapColors.institutoTransporte.strokeWidth
-          }}
+        <g style={getRoomStyle('intsTrans', isSelected('TOR-IDT'), hasSelection)}
           onClick={() => handleOpen?.('TOR-IDT')}
           className={`classRoom ${isSelected('TOR-IDT') ? 'selected' : ''}`}
         >
@@ -691,13 +651,7 @@ export default function TornaviasPrimerPiso({ selectedCode, handleOpen }: Tornav
           />
         </g>
         {/* Depto. de Servicios Académicos IT */}
-        <g
-          style={{
-            fill: mapColors.institutoTransporte.fill,
-            stroke: mapColors.institutoTransporte.stroke,
-            strokeWidth: mapColors.institutoTransporte.strokeWidth
-          }}
-        >
+        <g style={getMapStyle( mapColors.institutoTransporte, hasSelection )}>
           <path
             d="M210.342629,607.849939c-8.95236-10.244195-24.001911-29.443305-29.630071-38.554563l-45.059782,29.14993c9.959006,15.197656,26.950464,38.49425,34.551609,46.168097l40.138244-36.763464Z"
             transform="translate(0 0.000002)"
@@ -718,13 +672,7 @@ export default function TornaviasPrimerPiso({ selectedCode, handleOpen }: Tornav
         </g>
         {/* Centro de Atención Psicoanalítica UIS */}{' '}
         {/* //todo: Buscar la nueva ubicación de este departamanto*/ }
-        <g
-          style={{
-            fill: mapColors.centroDeAtencionPsico.fill,
-            stroke: mapColors.centroDeAtencionPsico.stroke,
-            strokeWidth: mapColors.centroDeAtencionPsico.strokeWidth
-          }}
-        >
+        <g style={getMapStyle( mapColors.centroDeAtencionPsico, hasSelection )}>
           <path
             d="M231.242577,455.079984c1.547165,7.554654,7.064444,23.381722,10.675336,31.773873l-33.635827,14.863117-12.725862-36.438078l35.686353-10.198912Z"
             transform="translate(.000002 0.000003)"
@@ -739,13 +687,7 @@ export default function TornaviasPrimerPiso({ selectedCode, handleOpen }: Tornav
         </g>
         {/*// todo: Verificar que aulas y distribucion tiene ex Escuela de Humanidades  */}
         {/* Escuela de Humanidades - Decanato*/}
-        <g
-          style={{
-            fill: mapColors.humanidades.fill,
-            stroke: mapColors.humanidades.stroke,
-            strokeWidth: mapColors.humanidades.strokeWidth
-          }}
-        >
+        <g style={getMapStyle( mapColors.humanidades, hasSelection )}>
           <path
             d="M319.840144,111.346257c75.14256-34.144216,183.160217-29.752161,239.623599-3.504649l19.94034-49.606132C554.43168,46.828812,520.222742,38.507192,482.348861,35.34659c-20.97359-1.750261-41.726158-3.452838-64.697033-2.5074-14.082876.579625-29.690977,2.864605-43.522461,5.394067-26.892728,4.918064-52.840999,13.426065-76.215197,24.628328l21.925974,48.484672Z"
             transform="translate(.000004 0.000003)"
@@ -759,13 +701,7 @@ export default function TornaviasPrimerPiso({ selectedCode, handleOpen }: Tornav
           />
         </g>
         {/* Escuela de Humanidades*/}
-        <g
-          style={{
-            fill: mapColors.humanidades.fill,
-            stroke: mapColors.humanidades.stroke,
-            strokeWidth: mapColors.humanidades.strokeWidth
-          }}
-        >
+        <g style={getMapStyle( mapColors.humanidades, hasSelection )}>
           <path
             d="M327.263643,213.98662c16.985138-8.970746,34.362269-18.323031,36.394122-18.70457c11.712036-4.510797,34.255949-10.272256,46.21096-12.246308c7.598843-.999778,23.499964-2.008385,34.331006-2.464214c5.499249-.587354,21.258824.049948,32.234073,1.17926c28.40594,4.353976,35.561281,8.44946,46.523058,12.146875l15.369602-33.261027c-7.626555-4.065091-26.271836-8.845666-38.519817-11.23854-10.108397-2.185029-27.761434-4.746005-37.801534-5.616096-27.100144-3.028411-37.227419-.996925-54.511777,1.251753-13.277425,1.82056-41.226825,9.255387-57.244986,15.602882-12.396231,4.411002-33.85388,14.752745-42.605448,21.114152l19.620734,32.235832"
             transform="translate(.000007 0.000001)"
@@ -780,13 +716,7 @@ export default function TornaviasPrimerPiso({ selectedCode, handleOpen }: Tornav
           />
         </g>
         {/* Dirección de Gérenro y Diversidad Sexual */}
-        <g
-          style={{
-            fill: mapColors.humanidades.fill,
-            stroke: mapColors.humanidades.stroke,
-            strokeWidth: mapColors.humanidades.strokeWidth
-          }}
-        >
+        <g style={getMapStyle( mapColors.humanidades, hasSelection )}>
           <path
             d="M340.355463,695.709143c-6.597881-2.317223-21.233509-8.03886-29.32171-11.342363l-10.972266,22.254985-29.096213-15.520702-14.116982,24.37659c18.184017,11.267016,51.055151,24.728614,65.59174,30.073223l17.915431-49.841733Z"
             transform="translate(.000001 0.000002)"
@@ -804,13 +734,7 @@ export default function TornaviasPrimerPiso({ selectedCode, handleOpen }: Tornav
           />
         </g>
         {/* Centro de Estudios Latinos-Americanos */}
-        <g
-          style={{
-            fill: mapColors.humanidades.fill,
-            stroke: mapColors.humanidades.stroke,
-            strokeWidth: mapColors.humanidades.strokeWidth
-          }}
-        >
+        <g style={getMapStyle( mapColors.humanidades, hasSelection )}>
           <path
             d="M283.571377,670.087322c5.84398,3.656365,19.830554,10.673608,27.462375,14.279456l-10.972267,22.254987-29.096213-15.520706l12.606105-21.013737Z"
             transform="translate(.000002 0.000004)"
@@ -1183,13 +1107,7 @@ export default function TornaviasPrimerPiso({ selectedCode, handleOpen }: Tornav
         </g>
         {/*........................................:Lectura Mundi:.................................................. */}
         {/* Lectura Mundi - Coordinación */}
-        <g
-          style={{
-            fill: mapColors.lecturaMundi.fill,
-            stroke: mapColors.lecturaMundi.stroke,
-            strokeWidth: mapColors.lecturaMundi.strokeWidth
-          }}
-        >
+        <g style={getMapStyle( mapColors.lecturaMundi, hasSelection )}>
           <path
             d="M364.376435,604.764542c-12.799056-4.543638-40.762397-18.829981-56.733526-34.449722l-24.869612,29.443841c16.473654,12.511506,49.854622,31.813607,67.47506,38.701918l14.128078-33.696037Z"
             transform="translate(0 0.000002)"
@@ -1206,13 +1124,7 @@ export default function TornaviasPrimerPiso({ selectedCode, handleOpen }: Tornav
           />
         </g>
         {/* Lectura Mundi Dirección */}
-        <g
-          style={{
-            fill: mapColors.lecturaMundi.fill,
-            stroke: mapColors.lecturaMundi.stroke,
-            strokeWidth: mapColors.lecturaMundi.strokeWidth
-          }}
-        >
+        <g style={getMapStyle( mapColors.lecturaMundi, hasSelection )}>
           <path
             d="M283.571379,670.087325c-5.305198-3.196616-16.584683-11.207046-22.601314-15.851484l-31.820886,43.112352c7.853285,5.623603,21.47811,14.845647,27.699114,18.129461l26.723086-45.390329Z"
             transform="translate(0 0.000001)"
@@ -1230,13 +1142,7 @@ export default function TornaviasPrimerPiso({ selectedCode, handleOpen }: Tornav
           />
         </g>
         {/* Lectura Mundi Administración */}
-        <g
-          style={{
-            fill: mapColors.lecturaMundi.fill,
-            stroke: mapColors.lecturaMundi.stroke,
-            strokeWidth: mapColors.lecturaMundi.strokeWidth
-          }}
-        >
+        <g style={getMapStyle( mapColors.lecturaMundi, hasSelection )}>
           <path
             d="M260.970064,654.235841l-26.23921-20.613338-36.122927,39.542329c8.558428,7.5473,24.015107,19.628812,30.541251,24.183361l31.820886-43.112352Z"
             transform="translate(.000001 0.000001)"

--- a/src/components/common/map/tornavias/TornaviasPrimerPiso.tsx
+++ b/src/components/common/map/tornavias/TornaviasPrimerPiso.tsx
@@ -1,17 +1,17 @@
 import { BookOpenText, CaretCircleUpDown, ForkKnife, Toilet } from '@phosphor-icons/react'
 import { mapColors } from '../../../pages/map/mapColors'
 import RoomText from '../RoomText'
+import { getRoomStyle } from '../RoomStyle'
 
 interface TornaviasPrimerPisoProps {
   selectedCode?: string // Cambiado de selectedClassRoomId
   handleOpen?: (classRoomId: string) => void
 }
 
-export default function TornaviasPrimerPiso({
-  selectedCode,
-  handleOpen
-}: TornaviasPrimerPisoProps) {
+export default function TornaviasPrimerPiso({ selectedCode, handleOpen }: TornaviasPrimerPisoProps) {
   const isSelected = (id: string) => id === selectedCode
+  const hasSelection = !!selectedCode //convierte selectedCode a boolean
+
   return (
     <>
       <svg
@@ -830,15 +830,9 @@ export default function TornaviasPrimerPiso({
         </g>
         {/* .......................................................:Laboratorios:................................................... */}
         {/* Lab. de Biomédica */}
-        <g
-          style={{
-            fill: mapColors.lab.fill,
-            stroke: mapColors.lab.stroke,
-            strokeWidth: mapColors.lab.strokeWidth
-          }}
+        <g style={getRoomStyle('lab', isSelected('TOR-LBM'), hasSelection)}
           onClick={() => handleOpen?.('TOR-LBM')}
-          className={`classRoom ${isSelected('TOR-LBM') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-LBM') ? 'selected' : ''}`}>
           <path d="M648.932918,481.725081c-6.72563,16.508337-23.875519,45.854964-34.995772,58.36084c10.699564,8.638894,25.144205,20.117947,28.261142,23.083734c13.481169-14.746894,33.384114-48.847337,40.462272-67.913721l-33.727642-13.530853Z" />
           <RoomText
             x={633} y={540}
@@ -852,15 +846,9 @@ export default function TornaviasPrimerPiso({
           />
         </g>
         {/* Lab. de Óptica */}
-        <g
-          style={{
-            fill: mapColors.lab.fill,
-            stroke: mapColors.lab.stroke,
-            strokeWidth: mapColors.lab.strokeWidth
-          }}
+        <g style={getRoomStyle('lab', isSelected('TOR-LO'), hasSelection)}
           onClick={() => handleOpen?.('TOR-LO')}
-          className={`classRoom ${isSelected('TOR-LO') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-LO') ? 'selected' : ''}`}>
           <path
             d="M658.702897,448.251373c2.597916-9.915621,5.366512-27.3622,5.344295-34.893157l37.298647,2.559433c-.851332,12.151571-3.703975,31.476879-5.547838,39.752744l-37.095104-7.41902Z"
             transform="translate(.000002 0.000004)"
@@ -876,15 +864,9 @@ export default function TornaviasPrimerPiso({
           />
         </g>
         {/* Lab. de Imágenes */}
-        <g
-          style={{
-            fill: mapColors.lab.fill,
-            stroke: mapColors.lab.stroke,
-            strokeWidth: mapColors.lab.strokeWidth
-          }}
+        <g style={getRoomStyle('lab', isSelected('TOR-LI'), hasSelection)}
           onClick={() => handleOpen?.('TOR-LI')}
-          className={`classRoom ${isSelected('TOR-LI') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-LI') ? 'selected' : ''}`}>
           <path d="M663.491106,379.269331l37.443302-2.056484c.514162,10.843138.867623,30.195541.411433,38.704806l-37.298649-2.559433c-.047288-9.17642-.116975-26.399805-.556086-34.088889Z" />
           <RoomText
             x={666} y={395}
@@ -897,15 +879,9 @@ export default function TornaviasPrimerPiso({
           />
         </g>
         {/* Lab. de Electrónica I */}
-        <g
-          style={{
-            fill: mapColors.lab.fill,
-            stroke: mapColors.lab.stroke,
-            strokeWidth: mapColors.lab.strokeWidth
-          }}
+        <g style={getRoomStyle('lab', isSelected('TOR-LE1'), hasSelection)}
           onClick={() => handleOpen?.('TOR-LE1')}
-          className={`classRoom ${isSelected('TOR-LE1') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-LE1') ? 'selected' : ''}`}>
           <path
             d="M713.854823,560.139867c7.026992-11.671915,18.219138-34.095264,21.937518-44.968544l50.201477,19.478795c-5.728432,14.975441-19.892653,41.721972-26.562537,52.757043l-45.576458-27.267294Z"
             transform="translate(.000003 0.000002)"
@@ -922,15 +898,9 @@ export default function TornaviasPrimerPiso({
           />
         </g>
         {/* Lab. de Electrónica III */}
-        <g
-          style={{
-            fill: mapColors.lab.fill,
-            stroke: mapColors.lab.stroke,
-            strokeWidth: mapColors.lab.strokeWidth
-          }}
+        <g style={getRoomStyle('lab', isSelected('TOR-LE3'), hasSelection)}
           onClick={() => handleOpen?.('TOR-LE3')}
-          className={`classRoom ${isSelected('TOR-LE3') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-LE3') ? 'selected' : ''}`}>
           <path
             d="M686.36613,599.005661c7.53362-8.416957,21.046323-27.94739,27.488693-38.865796l45.576461,27.267296c-7.521165,12.859758-22.770763,35.555239-31.708892,45.079683L686.36613,599.005661Z"
             transform="translate(0 0.000002)"
@@ -947,15 +917,9 @@ export default function TornaviasPrimerPiso({
           />
         </g>
         {/* Lab. de Electrónica IV */}
-        <g
-          style={{
-            fill: mapColors.lab.fill,
-            stroke: mapColors.lab.stroke,
-            strokeWidth: mapColors.lab.strokeWidth
-          }}
+        <g style={getRoomStyle('lab', isSelected('TOR-LE4'), hasSelection)}
           onClick={() => handleOpen?.('TOR-LE4')}
-          className={`classRoom ${isSelected('TOR-LE4') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-LE4') ? 'selected' : ''}`} >
           <path
             d="M686.36613,599.005662c-7.977895,9.187551-25.525271,27.40743-34.921488,36.366895l34.921488,40.019622c12.92596-11.056137,34.078171-32.255071,41.356262-42.905336L686.36613,599.005662Z"
             transform="translate(0 0.000001)"
@@ -972,12 +936,7 @@ export default function TornaviasPrimerPiso({
           />
         </g>
         {/* Lab. de Computación I*/}
-        <g
-          style={{
-            fill: mapColors.lab.fill,
-            stroke: mapColors.lab.stroke,
-            strokeWidth: mapColors.lab.strokeWidth
-          }}
+        <g style={getRoomStyle('lab', isSelected('TOR-LC1'), hasSelection)}
           onClick={() => handleOpen?.('TOR-LC1')}
           className={`classRoom ${isSelected('TOR-LC1') ? 'selected' : ''}`}
         >
@@ -996,12 +955,7 @@ export default function TornaviasPrimerPiso({
           />
         </g>
         {/* Lab. de Computación II*/}
-        <g
-          style={{
-            fill: mapColors.lab.fill,
-            stroke: mapColors.lab.stroke,
-            strokeWidth: mapColors.lab.strokeWidth
-          }}
+        <g style={getRoomStyle('lab', isSelected('TOR-LC2'), hasSelection)}
           onClick={() => handleOpen?.('TOR-LC2')}
           className={`classRoom ${isSelected('TOR-LC2') ? 'selected' : ''}`}
         >
@@ -1020,15 +974,9 @@ export default function TornaviasPrimerPiso({
           />
         </g>
         {/* Lab. de Computación III*/}
-        <g
-          style={{
-            fill: mapColors.lab.fill,
-            stroke: mapColors.lab.stroke,
-            strokeWidth: mapColors.lab.strokeWidth
-          }}
+        <g style={getRoomStyle('lab', isSelected('TOR-LC3'), hasSelection)}
           onClick={() => handleOpen?.('TOR-LC3')}
-          className={`classRoom ${isSelected('TOR-LC3') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-LC3') ? 'selected' : ''}`} >
           <path
             d="M657.525225,344.601715l36.56069-8.680129c2.411818,10.306226,5.853031,30.949029,6.848493,41.29126l-37.443305,2.056482c-1.259175-11.025439-3.561545-28.359246-5.965878-34.667613Z"
             transform="translate(.000003 0.000003)"
@@ -1044,12 +992,7 @@ export default function TornaviasPrimerPiso({
           />
         </g>
         {/* Laboratorio de Ciencias Humanas LICH */}
-        <g
-          style={{
-            fill: mapColors.humanidades.fill,
-            stroke: mapColors.humanidades.stroke,
-            strokeWidth: mapColors.humanidades.strokeWidth
-          }}
+        <g style={getRoomStyle('lab_h', isSelected('TOR-LCH'), hasSelection)}
           onClick={() => handleOpen?.('TOR-LCH')}
           className={`classRoom ${isSelected('TOR-LCH') ? 'selected' : ''}`}
         >
@@ -1071,15 +1014,9 @@ export default function TornaviasPrimerPiso({
         </g>
         {/* .......................................................:Aulas:......................................................... */}
         {/* CIDI*/}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-CIDI'), hasSelection)}
           onClick={() => handleOpen?.('TOR-CIDI')}
-          className={`classRoom ${isSelected('TOR-CIDI') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-CIDI') ? 'selected' : ''}`} >
           <path
             d="M613.053706,664.880487c11.863397-7.530674,31.319727-22.249068,38.390936-29.507933l34.921488,40.019623c-11.407792,10.09239-32.917574,27.508741-44.99751,34.354024l-28.314914-44.865714Z"
             transform="translate(0 0.000003)"
@@ -1093,34 +1030,20 @@ export default function TornaviasPrimerPiso({
           />
         </g>
         {/* A30 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A30'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A30')}
-          className={`classRoom ${isSelected('TOR-A30') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A30') ? 'selected' : ''}`}>
           <path d="M569.382208,687.668369c11.707026-4.582715,33.386844-16.075886,43.6715-22.787882l28.314912,44.865716c-8.243741,6.165504-32.268534,19.027766-50.201334,26.374608l-21.785078-48.452442Z" />
           <RoomText
             x={590} y={705}
             fontSize={15}
-            lines={[
-              { text: 'A30' },
-            ]}
+            lines={[ { text: 'A30' }, ]}
           />
         </g>
         {/* A31 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A31'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A31')}
-          className={`classRoom ${isSelected('TOR-A31') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A31') ? 'selected' : ''}`} >
           <path
             d="M467.679414,655.491182l-2.983209-36.389147c11.520256-.65545,28.740423-3.95531,34.490184-6.387994l9.412642,35.654853c-9.924211,2.468117-30.331558,5.986-40.919617,7.122288Z"
             transform="translate(0 0.000002)"
@@ -1128,21 +1051,13 @@ export default function TornaviasPrimerPiso({
           <RoomText
             x={472} y={641}
             fontSize={15}
-            lines={[
-              { text: 'A31' },
-            ]}
+            lines={[ { text: 'A31' }, ]}
           />
         </g>
         {/* A32 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A32'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A32')}
-          className={`classRoom ${isSelected('TOR-A32') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A32') ? 'selected' : ''}`} >
           <path
             d="M467.679414,655.491182c-9.738725.496311-29.106775.658002-38.73736.329683l2.103313-36.384182c9.02163.42267,25.861483.557099,33.650838-.334647l2.983209,36.389146Z"
             transform="translate(0 0.000001)"
@@ -1150,21 +1065,13 @@ export default function TornaviasPrimerPiso({
           <RoomText
             x={434} y={642}
             fontSize={15}
-            lines={[
-              { text: 'A32' },
-            ]}
+            lines={[ { text: 'A32' }, ]}
           />
         </g>
         {/* A33*/}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A33'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A33')}
-          className={`classRoom ${isSelected('TOR-A33') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A33') ? 'selected' : ''}`} >
           <path
             d="M428.942054,655.820861c-11.951641-1.224391-32.1554-3.843076-40.249958-5.788836l8.137832-35.107795c8.439514,2.530668,25.472213,4.218114,34.215439,4.51245l-2.103313,36.384181Z"
             transform="translate(0 0.000004)"
@@ -1172,9 +1079,7 @@ export default function TornaviasPrimerPiso({
           <RoomText
             x={396} y={642}
             fontSize={15}
-            lines={[
-              { text: 'A33' },
-            ]}
+            lines={[ { text: 'A33' }, ]}
           />
         </g>
         {/* A34 */}{/* //TODO: Buscar la ubicación de esta aula  */}
@@ -1200,15 +1105,9 @@ export default function TornaviasPrimerPiso({
           />
         </g>
         {/* A35 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-A35'), hasSelection)}
           onClick={() => handleOpen?.('TOR-A35')}
-          className={`classRoom ${isSelected('TOR-A35') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-A35') ? 'selected' : ''}`} >
           <path
             d="M522.956868,193.897662c8.498459,3.846212,23.24087,11.836283,29.419859,15.992322l20.089871-31.003693c-9.164108-5.103664-26.152433-14.248928-34.140133-18.249657l-15.369597,33.261028Z"
             transform="translate(.000001 0.000002)"
@@ -1216,16 +1115,14 @@ export default function TornaviasPrimerPiso({
           <RoomText
             x={533} y={190}
             fontSize={15}
-            lines={[
-              { text: 'A35' },
-            ]}
+            lines={[ { text: 'A35' }, ]}
           />
         </g>
 
         {/*Talleres de Arquitectura*/}
-        <g onClick={() => handleOpen?.('TOR-T03')}
-          className={`classRoom ${isSelected('TOR-T03') ? 'selected' : ''}`}
-          style={{ fill: mapColors.classrooms.fill, stroke: mapColors.classrooms.stroke, strokeWidth: mapColors.classrooms.strokeWidth }}>
+        <g style={getRoomStyle('classroom', isSelected('TOR-T03'), hasSelection)}
+          onClick={() => handleOpen?.('TOR-T03')}
+          className={`classRoom ${isSelected('TOR-T03') ? 'selected' : ''}`} >
           <path
             d="M231.242577,455.079984c1.547165,7.554654,7.064444,23.381722,10.675336,31.773873l-33.635827,14.863117c-4.275043-8.620784-10.602577-26.851622-12.725862-36.438078l35.686353-10.198912Z"
             transform="translate(.000002 0.000003)"
@@ -1246,15 +1143,9 @@ export default function TornaviasPrimerPiso({
           </text>
         </g>
         {/* T04 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-T04'), hasSelection)}
           onClick={() => handleOpen?.('TOR-T04')}
-          className={`classRoom ${isSelected('TOR-T04') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-T04') ? 'selected' : ''}`} >
           <path
             d="M189.084671,385.5h36.726157c-.881459,17.006431-.678467,51.976619,5.431749,69.579987l-35.686352,10.19891c-6.777362-19.106295-7.312686-60.203014-6.471554-79.778897Z"
             transform="translate(.000001 0)"
@@ -1262,21 +1153,13 @@ export default function TornaviasPrimerPiso({
           <RoomText
             x={194} y={430}
             fontSize={15}
-            lines={[
-              { text: 'T04' },
-            ]}
+            lines={[ { text: 'T04' }, ]}
           />
         </g>
         {/* T05 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-T05'), hasSelection)}
           onClick={() => handleOpen?.('TOR-T05')}
-          className={`classRoom ${isSelected('TOR-T05') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-T05') ? 'selected' : ''}`} >
           <path
             d="M210.536771,607.156266c-8.95236-10.244195-23.307909-29.861084-28.936069-38.972342l-45.799196,29.725531c9.959006,15.197656,27.791542,38.506199,35.392687,46.180046l39.342578-36.933235Z"
             transform="matrix(.88383 0.467809-.467809 0.88383 238.197352-155.20719)"
@@ -1284,28 +1167,18 @@ export default function TornaviasPrimerPiso({
           <RoomText
             x={95} y={465}
             fontSize={15}
-            lines={[
-              { text: 'T05' },
-            ]}
+            lines={[ { text: 'T05' }, ]}
           />
         </g>
         {/* T06 */}
-        <g
-          style={{
-            fill: mapColors.classrooms.fill,
-            stroke: mapColors.classrooms.stroke,
-            strokeWidth: mapColors.classrooms.strokeWidth
-          }}
+        <g style={getRoomStyle('classroom', isSelected('TOR-T06'), hasSelection)}
           onClick={() => handleOpen?.('TOR-T06')}
-          className={`classRoom ${isSelected('TOR-T06') ? 'selected' : ''}`}
-        >
+          className={`classRoom ${isSelected('TOR-T06') ? 'selected' : ''}`} >
           <path d="M132.900095,431.925056l-54.384554,4.847048c-4.099336-28.608807-2.449949-86.175658,6.534544-116.869438l53.57151,11.607649c-8.670179,29.583261-8.787787,77.526784-5.7215,100.414741Z" />
           <RoomText
             x={90} y={390}
             fontSize={15}
-            lines={[
-              { text: 'T06' },
-            ]}
+            lines={[ { text: 'T06' }, ]}
           />
         </g>
         {/*........................................:Lectura Mundi:.................................................. */}

--- a/src/components/common/map/tornavias/TornaviasSubsuelo.tsx
+++ b/src/components/common/map/tornavias/TornaviasSubsuelo.tsx
@@ -1,6 +1,7 @@
 import { BookOpenText, Toilet } from '@phosphor-icons/react'
 import { mapColors } from '../../../pages/map/mapColors'
 import { getRoomStyle } from '../RoomStyle'
+import { getMapStyle } from '../MapStyle'
 
 interface TornaviasSubsueloProps {
   selectedCode?: string // Cambiado de selectedClassRoomId
@@ -208,12 +209,7 @@ export default function TornaviasSubsuelo({ selectedCode, handleOpen }: Tornavia
             </text>
           </g>
           {/* Lectura Mundi Comunicación Identidad Visual */}
-          <g
-            style={{
-              fill: mapColors.lecturaMundi.fill,
-              stroke: mapColors.lecturaMundi.stroke,
-              strokeWidth: mapColors.lecturaMundi.strokeWidth
-            }}
+          <g style={getMapStyle( mapColors.lecturaMundi, hasSelection )}
             transform="translate(.000001 0.000001)">
             <path
               d="M163.777204,367.564469c3.994251,27.061452,27.310193,73.710364,47.051268,93.109102l36.751213-32.672082c-13.962233-13.477412-31.78846-47.477558-34.827329-68.698472l-48.975152,8.261452Z"
@@ -386,20 +382,11 @@ export default function TornaviasSubsuelo({ selectedCode, handleOpen }: Tornavia
             </text>
           </g>
           {/* Gerencia de Informática Soporte Técnico */}
-          <g
-            style={{
-              fill: mapColors.commonAreas.fill,
-              stroke: mapColors.commonAreas.stroke,
-              strokeWidth: mapColors.commonAreas.strokeWidth
-            }}
+          <g style={getMapStyle( mapColors.commonAreas, hasSelection )}
             transform="translate(0 0.000001)">
             <path
               d="M573.606346,434.718077l-20.752469,34.760868l45.815688,31.628575c7.996447-10.747864,20.887156-32.37141,25.652834-43.268522l-50.716053-23.120921Z"
-              transform="translate(.000001-.028904)"
-              fill="#9699a1"
-              stroke="#505050"
-              strokeWidth="0.7"
-            />
+              transform="translate(.000001-.028904)"/>
             <text
               dx="0"
               dy="0"
@@ -419,14 +406,7 @@ export default function TornaviasSubsuelo({ selectedCode, handleOpen }: Tornavia
           </g>
           {/* .........................................:IAMK:........................................................................*/}
           {/* IAMK */}
-          <g
-            style={{
-              fill: mapColors.iAMK.fill,
-              stroke: mapColors.iAMK.stroke,
-              strokeWidth: mapColors.iAMK.strokeWidth
-            }}
-            transform="translate(0 0.000001)"
-          >
+          <g style={getMapStyle( mapColors.iAMK, hasSelection )} transform="translate(0 0.000001)" >
             <path
               d="M552.853878,469.450041c-5.199325,6.945144-18.767134,22.428585-27.127554,30.962849l39.909481,39.322713c10.065025-9.651156,26.734904-28.9414,33.03376-38.656988l-45.815687-31.628574Z"
               transform="translate(.000001 0.000001)"
@@ -447,14 +427,7 @@ export default function TornaviasSubsuelo({ selectedCode, handleOpen }: Tornavia
             </text>
           </g>
           {/* IAMK Servicios */}
-          <g
-            style={{
-              fill: mapColors.iAMK.fill,
-              stroke: mapColors.iAMK.stroke,
-              strokeWidth: mapColors.iAMK.strokeWidth
-            }}
-            transform="translate(0 0.000001)"
-          >
+          <g style={getMapStyle( mapColors.iAMK, hasSelection )} transform="translate(0 0.000001)" >
             <path d="M456.583909,547.452094c-9.774067,4.179228-29.597963,11.308888-39.669812,14.215282L430.42164,614.12842c13.015658-2.971658,37.650561-11.502414,49.290329-17.027303l-23.12806-49.649023Z" />
             <text
               dx="0"
@@ -475,13 +448,7 @@ export default function TornaviasSubsuelo({ selectedCode, handleOpen }: Tornavia
             </text>
           </g>
           {/* IAMK Decanato */}
-          <g
-            style={{
-              fill: mapColors.iAMK.fill,
-              stroke: mapColors.iAMK.stroke,
-              strokeWidth: mapColors.iAMK.strokeWidth
-            }}
-            transform="translate(0 0.000001)">
+          <g style={getMapStyle( mapColors.iAMK, hasSelection )} transform="translate(0 0.000001)">
             <path
               d="M416.914097,561.667376c-11.052498,2.765574-31.966516,6.307018-42.064177,6.551575l4.119723,54.91027c13.045229-.839876,38.75822-5.389702,51.451995-9.000803l-13.507541-52.461042Z"
               transform="translate(.000002 0.000004)"

--- a/src/components/common/map/tornavias/TornaviasSubsuelo.tsx
+++ b/src/components/common/map/tornavias/TornaviasSubsuelo.tsx
@@ -1,17 +1,16 @@
 import { BookOpenText, Toilet } from '@phosphor-icons/react'
 import { mapColors } from '../../../pages/map/mapColors'
+import { getRoomStyle } from '../RoomStyle'
 
 interface TornaviasSubsueloProps {
   selectedCode?: string // Cambiado de selectedClassRoomId
   handleOpen?: (classRoomId: string) => void
 }
 
-export default function TornaviasSubsuelo({
-  selectedCode,
-  handleOpen
-}: TornaviasSubsueloProps) {
+export default function TornaviasSubsuelo({ selectedCode, handleOpen }: TornaviasSubsueloProps) {
   const isSelected = (id: string) => id === selectedCode
-
+  const hasSelection = !!selectedCode //convierte selectedCode a boolean
+  
   // !important: Si se quiere volver a la posición original, sacar el rotate y reemplazar las coordenadas comentadas por las actuales.
   // todo-> viewBox="minX minY width height"    (minX;minY) ancho alto
   return (
@@ -270,7 +269,7 @@ export default function TornaviasSubsuelo({
           </g>
           {/* ......................................................:Aulas:........................................................................... */}
           {/* A27 */}
-          <g style={{ fill: mapColors.classrooms.fill, stroke: mapColors.classrooms.stroke, strokeWidth: mapColors.classrooms.strokeWidth }}
+          <g style={getRoomStyle('classroom', isSelected('TOR-A27'), hasSelection)}
             onClick={() => handleOpen?.('TOR-A27')} transform="translate(.000001 0)"
             className={`classRoom ${isSelected('TOR-A27') ? 'selected' : ''}`} >
             <path
@@ -291,16 +290,10 @@ export default function TornaviasSubsuelo({
             </text>
           </g>
           {/* A26 */}
-          <g
-            style={{
-              fill: mapColors.classrooms.fill,
-              stroke: mapColors.classrooms.stroke,
-              strokeWidth: mapColors.classrooms.strokeWidth
-            }}
+          <g style={getRoomStyle('classroom', isSelected('TOR-A26'), hasSelection)}
             onClick={() => handleOpen?.('TOR-A26')}
             transform="translate(.000001 0)"
-            className={`classRoom ${isSelected('TOR-A26') ? 'selected' : ''}`}
-          >
+            className={`classRoom ${isSelected('TOR-A26') ? 'selected' : ''}`} >
             <path
               d="M390.627876,467.883894l12.963961,47.297694c17.514813-5.107595,47.937744-18.736399,60.46326-27.892047l-28.689661-39.3772c-10.428627,7.307407-32.766706,17.369936-44.737562,19.971553"
               transform="translate(.000003 0)"
@@ -320,15 +313,9 @@ export default function TornaviasSubsuelo({
             </text>
           </g>
           {/* A25 Lab. de Artes Digitales*/}
-          <g
-            style={{
-              fill: mapColors.classrooms.fill,
-              stroke: mapColors.classrooms.stroke,
-              strokeWidth: mapColors.classrooms.strokeWidth
-            }}
+          <g style={getRoomStyle('classroom', isSelected('TOR-A25'), hasSelection)}
             onClick={() => handleOpen?.('TOR-A25')}
-            className={`classRoom ${isSelected('TOR-A25') ? 'selected' : ''}`}
-          >
+            className={`classRoom ${isSelected('TOR-A25') ? 'selected' : ''}`} >
             <path
               d="M464.0551,487.289541c22.515861-13.872036,54.947443-50.182526,63.920489-73.397303l-45.488801-20.764782c-7.012486,17.055566-30.99735,44.06238-47.121349,54.784883L464.0551,487.289538"
               transform="translate(0 0.000004)"
@@ -354,7 +341,7 @@ export default function TornaviasSubsuelo({
             </text>
           </g>
           {/* A28 */}
-          <g style={{ fill: mapColors.classrooms.fill, stroke: mapColors.classrooms.stroke, strokeWidth: mapColors.classrooms.strokeWidth }}
+          <g style={getRoomStyle('classroom', isSelected('TOR-A28'), hasSelection)}
             onClick={() => handleOpen?.('TOR-A28')} transform="translate(.000001 0)"
             className={`classRoom ${isSelected('TOR-A28') ? 'selected' : ''}`}>
             <path
@@ -375,12 +362,7 @@ export default function TornaviasSubsuelo({
             </text>
           </g>
           {/* A29 */}
-          <g
-            style={{
-              fill: mapColors.classrooms.fill,
-              stroke: mapColors.classrooms.stroke,
-              strokeWidth: mapColors.classrooms.strokeWidth
-            }}
+          <g style={getRoomStyle('classroom', isSelected('TOR-A29'), hasSelection)}
             onClick={() => handleOpen?.('TOR-A29')}
             transform="translate(.000001 0)"
             className={`classRoom ${isSelected('TOR-A29') ? 'selected' : ''}`}

--- a/src/components/pages/map/mapColors.tsx
+++ b/src/components/pages/map/mapColors.tsx
@@ -91,8 +91,8 @@ export const mapColors = {
     strokeWidth: 0.7
   },
   institutoTransporte: {
-    fill: '#10245b',
-    stroke: '#b8ddff', //#10245b
+    fill: '#b8ddff',  //#b8ddff
+    stroke: '#10245b', //#10245b
     strokeWidth: 0.7
   },
   centroDeAtencionPsico: {
@@ -101,7 +101,7 @@ export const mapColors = {
     strokeWidth: 0.7
   },
   iAMK: {
-    fill: '#7a2bc5',
+    fill: '#8f3de0', //#7a2bc5',
     stroke: '#552281',
     strokeWidth: 0.7
   },


### PR DESCRIPTION
Buenas! 
Se creó función getRoomStyle la lógica de estilos dinámicos de aulas y laboratorios dentro de los mapas.
<img width="2296" height="2452" alt="imagen" src="https://github.com/user-attachments/assets/5f412903-cb35-4124-bdb7-2d51a85db5b3" />

Esta implementación permite determinar dinámicamente los colores y bordes de cada tipo de aula. Cuando un aula o laboratorio se encuentra seleccionado, se resalta en color rojo para poder identificarlo mas fácilmente., cuando existe una selección activa, el resto de los ambientes se muestran atenuados mediante colores neutros para resaltar el aula que queremos destacar del resto
<img width="1769" height="843" alt="imagen" src="https://github.com/user-attachments/assets/b8c97d34-752c-4d11-af4e-87d6d0a3ad6b" />
<img width="1860" height="970" alt="imagen" src="https://github.com/user-attachments/assets/2d8c9f19-3e1f-45e7-8899-d2f3df6e5904" />

---
Closes #58 